### PR TITLE
Fix image test to reflect API requirements

### DIFF
--- a/tests/models/compute/image_tests.rb
+++ b/tests/models/compute/image_tests.rb
@@ -1,6 +1,6 @@
 require 'securerandom'
 Shindo.tests("Fog::Compute[:google] | image model", ['google']) do
   random_string = SecureRandom.hex
-  source = 'https://www.google.com/images/srpr/logo4w.png'
+  source = 'http://storage.googleapis.com/fog-test-bucket/fog-test-raw-disk-source.image.tar.gz'
   model_tests(Fog::Compute[:google].images, {:name => "fog-test-images-#{random_string}", "rawDisk" => { "source" => source } })
 end

--- a/tests/models/compute/images_tests.rb
+++ b/tests/models/compute/images_tests.rb
@@ -1,6 +1,6 @@
 require 'securerandom'
 Shindo.tests("Fog::Compute[:google] | images model", ['google']) do
   random_string = SecureRandom.hex
-  source = 'https://www.google.com/images/srpr/logo4w.png'
+  source = 'http://storage.googleapis.com/fog-test-bucket/fog-test-raw-disk-source.image.tar.gz'
   collection_tests(Fog::Compute[:google].images, {:name => "fog-test-images-#{random_string}", "rawDisk" => { "source" => source } })
 end


### PR DESCRIPTION
- The Shindo tests should reference an actual image on Google Cloud Storage
- Related to, but does not close, #22