### PR TITLE
Get IP address by name

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,3 +39,4 @@
 * Timur Alperovich <timur.alperovich@gmail.com>
 * unknown <bturner_2@pibuk-lp71.pibenchmark.com>
 * Wesley Beary <geemus@gmail.com>
+* Google Inc.

--- a/lib/fog/google/models/compute/addresses.rb
+++ b/lib/fog/google/models/compute/addresses.rb
@@ -34,6 +34,19 @@ module Fog
           return nil if address.empty?
           new(address.first['addresses'].first)
         end
+
+        def get_by_name(ip_name)
+          names = service.list_aggregated_addresses(:filter => "name eq .*#{ip_name}").body['items']
+          name = names.each_value.select { |region| region.key?('addresses') }
+
+          return nil if name.empty?
+          new(name.first['addresses'].first)
+        end
+
+        def get_by_ip_address_or_name(ip_address_or_name)
+          get_by_ip_address(ip_address_or_name) or get_by_name(ip_address_or_name)
+        end
+
       end
     end
   end


### PR DESCRIPTION
Adding a get_by_name method to allow fetching of an IP address by name.

P.S. I needed to add a line to contributors, since this change is a part of my work at Google.

CC/ @erjohnso 
This change is made to later implement this feature in vagrant-google.