### PR TITLE
Adding bitnami-launchpad global project

### DIFF
--- a/lib/fog/google/models/compute/images.rb
+++ b/lib/fog/google/models/compute/images.rb
@@ -18,7 +18,8 @@ module Fog
           'opensuse-cloud',
           'rhel-cloud',
           'suse-cloud',
-          'ubuntu-os-cloud'
+          'ubuntu-os-cloud',
+          'bitnami-launchpad'
         ]
 
         def all


### PR DESCRIPTION
We offer an up to date public catalog of open source application images on GCE.

The community might be interested in accessing to those images via fog.

Thank you for your work on this library! :)

```
gcloud compute images list --project bitnami-launchpad
NAME                                                    PROJECT           ALIAS              DEPRECATED STATUS
bitnami-abantecart-1-2-1-0-linux-debian-7-x86-64        bitnami-launchpad                               READY
bitnami-activemq-5-11-1-0-linux-debian-7-x86-64         bitnami-launchpad                               READY
bitnami-akeneo-1-3-9-0-linux-debian-7-x86-64            bitnami-launchpad                               READY
....
```

