### PR TITLE
Override current project ID on images list/get operations

### DIFF
--- a/lib/fog/google/models/compute/images.rb
+++ b/lib/fog/google/models/compute/images.rb
@@ -18,7 +18,8 @@ module Fog
           'opensuse-cloud',
           'rhel-cloud',
           'suse-cloud',
-          'ubuntu-os-cloud'
+          'ubuntu-os-cloud',
+          'bitnami-launchpad'
         ]
 
         def all

--- a/lib/fog/google/models/compute/images.rb
+++ b/lib/fog/google/models/compute/images.rb
@@ -18,13 +18,16 @@ module Fog
           'opensuse-cloud',
           'rhel-cloud',
           'suse-cloud',
-          'ubuntu-os-cloud',
-          'bitnami-launchpad'
+          'ubuntu-os-cloud'
         ]
 
-        def all
+        # Returns the current or a specific project (if provided) images
+        # followed by the global project ones. Same behaviour than
+        # https://cloud.google.com/sdk/gcloud/reference/compute/images/list
+        def all(options = {})
+          project_id = options[:project] || self.service.project
           data = []
-          all_projects = GLOBAL_PROJECTS + [ self.service.project ]
+          all_projects = [ project_id ] + GLOBAL_PROJECTS
 
           all_projects.each do |project|
             begin
@@ -43,9 +46,9 @@ module Fog
           load(data)
         end
 
-        def get(identity)
-          # Search own project before global projects
-          all_projects = [ self.service.project ] + GLOBAL_PROJECTS
+        def get(identity, options = {})
+          project_id = options[:project] || self.service.project
+          all_projects = [ project_id ] + GLOBAL_PROJECTS
 
           data = nil
           all_projects.each do |project|

--- a/lib/fog/google/models/compute/images.rb
+++ b/lib/fog/google/models/compute/images.rb
@@ -21,12 +21,12 @@ module Fog
           'ubuntu-os-cloud'
         ]
 
-        # Returns the current or a specific project (if provided) images
-        # followed by the global project ones. Same behaviour than
+        # Returns the current or a specific project (if provided) images,
+        # followed by the global projects ones. Same behaviour than
         # https://cloud.google.com/sdk/gcloud/reference/compute/images/list
         def all(options = {})
-          project_id = options[:project] || self.service.project
           data = []
+          project_id = options[:project] || self.service.project
           all_projects = [ project_id ] + GLOBAL_PROJECTS
 
           all_projects.each do |project|


### PR DESCRIPTION
Following the same behaviour than the official gcloud CLI (attached image), now it is possible to pass a project option to override the target project ID.

* If no project parameter is passed, the project related to the service is used.
* The current or specific project images takes preference on the returned list. 
* This override affects to both list and describe API calls.

![selection_378](https://cloud.githubusercontent.com/assets/24523/7383390/5e31127a-edd3-11e4-827e-aa999c706a01.png)
