### PR TITLE
google_extra_global_projects on initialization for compute

### DIFF
--- a/lib/fog/google/compute.rb
+++ b/lib/fog/google/compute.rb
@@ -220,9 +220,11 @@ module Fog
 
       class Mock
         include Fog::Google::Shared
+        attr_reader :extra_global_projects
 
         def initialize(options)
           shared_initialize(options[:google_project], GOOGLE_COMPUTE_API_VERSION, GOOGLE_COMPUTE_BASE_URL)
+          @extra_global_projects = options[:google_extra_global_projects] || []
         end
 
         def self.data(api_version)

--- a/lib/fog/google/compute.rb
+++ b/lib/fog/google/compute.rb
@@ -3,7 +3,7 @@ module Fog
     class Google < Fog::Service
       requires :google_project
       recognizes :app_name, :app_version, :google_client_email, :google_key_location, :google_key_string,
-                 :google_client, :google_json_key_location, :google_json_key_string
+                 :google_client, :google_json_key_location, :google_json_key_string, :google_extra_global_projects
 
       GOOGLE_COMPUTE_API_VERSION     = 'v1'
       GOOGLE_COMPUTE_BASE_URL        = 'https://www.googleapis.com/compute/'
@@ -1050,7 +1050,7 @@ module Fog
         include Fog::Google::Shared
 
         attr_accessor :client
-        attr_reader :compute
+        attr_reader :compute, :extra_global_projects
 
         def initialize(options)
           shared_initialize(options[:google_project], GOOGLE_COMPUTE_API_VERSION, GOOGLE_COMPUTE_BASE_URL)
@@ -1059,6 +1059,7 @@ module Fog
           @client = initialize_google_client(options)
           @compute = @client.discovered_api('compute', api_version)
           @resourceviews = @client.discovered_api('resourceviews', 'v1beta1')
+          @extra_global_projects = options[:google_extra_global_projects] || []
         end
       end
 

--- a/lib/fog/google/models/compute/images.rb
+++ b/lib/fog/google/models/compute/images.rb
@@ -18,7 +18,8 @@ module Fog
           'opensuse-cloud',
           'rhel-cloud',
           'suse-cloud',
-          'ubuntu-os-cloud'
+          'ubuntu-os-cloud',
+          'bitnami-launchpad'
         ]
 
         def all

--- a/lib/fog/google/models/compute/images.rb
+++ b/lib/fog/google/models/compute/images.rb
@@ -18,13 +18,12 @@ module Fog
           'opensuse-cloud',
           'rhel-cloud',
           'suse-cloud',
-          'ubuntu-os-cloud',
-          'bitnami-launchpad'
+          'ubuntu-os-cloud'
         ]
 
         def all
           data = []
-          all_projects = GLOBAL_PROJECTS + [ self.service.project ]
+          all_projects = [ self.service.project ] + global_projects
 
           all_projects.each do |project|
             begin
@@ -45,7 +44,7 @@ module Fog
 
         def get(identity)
           # Search own project before global projects
-          all_projects = [ self.service.project ] + GLOBAL_PROJECTS
+          all_projects = [ self.service.project ] + global_projects
 
           data = nil
           all_projects.each do |project|
@@ -60,6 +59,12 @@ module Fog
           end
           return nil if data.nil?
           new(data)
+        end
+
+        private
+
+        def global_projects
+          GLOBAL_PROJECTS + self.service.extra_global_projects
         end
       end
     end


### PR DESCRIPTION
Added the option for setting extra global projects during initialization.

My previous approach did not fully work if you want to rely on these extra global projects for disk creation for example. https://github.com/fog/fog-google/pull/29   