### PR TITLE
correct :user to :username in launch instance example

### DIFF
--- a/examples/launch_micro_instance.rb
+++ b/examples/launch_micro_instance.rb
@@ -14,7 +14,7 @@ def test
     :machine_type => "f1-micro",
     :zone_name => "us-central1-a",
     :disks => [ disk.get_as_boot_disk(true) ],
-    :user => ENV['USER']
+    :username => ENV['USER']
   }
 
   server = connection.servers.bootstrap params


### PR DESCRIPTION
As written, the instance will always be created with a username matching ENV['USER']  If you send the parameter as 'username' it works as expected.