### PR TITLE
Tiny comment ambiguity fix for image_create example

### DIFF
--- a/examples/image_create.rb
+++ b/examples/image_create.rb
@@ -2,7 +2,7 @@ def test
   connection = Fog::Compute.new({ :provider => "Google" })
 
   rawdisk = {
-    :source         => nil, # 'http://some_valid_url_to_rootfs_tarball'
+    :source         => nil, # Google Cloud Storage URL pointing to the disk image. (e.g. http://storage.googleapis.com/test/test.tar.gz)
     :container_type => 'TAR',
   }
 


### PR DESCRIPTION
Link now needs a valid Google Storage URL.
Related context (API change): https://github.com/fog/fog-google/issues/22
Probably related issue: #40 