### PR TITLE
Allowing whitespace when uploading to google cloud

### DIFF
--- a/lib/fog/google.rb
+++ b/lib/fog/google.rb
@@ -28,6 +28,16 @@ module Fog
     service(:storage,    'Storage')
     service(:sql,        'SQL')
 
+    # CGI.escape, but without special treatment on spaces
+    def self.escape(str,extra_exclude_chars = '')
+      # '-' is a special character inside a regex class so it must be first or last.
+      # Add extra excludes before the final '-' so it always remains trailing, otherwise
+      # an unwanted range is created by mistake.
+      str.gsub(/([^a-zA-Z0-9_.#{extra_exclude_chars}-]+)/) do
+        '%' + $1.unpack('H2' * $1.bytesize).join('%').upcase
+      end
+    end
+    
     class Mock
       def self.etag
         hex(32)

--- a/lib/fog/google/requests/storage/copy_object.rb
+++ b/lib/fog/google/requests/storage/copy_object.rb
@@ -32,7 +32,7 @@ module Fog
             :host     => "#{target_bucket_name}.#{@host}",
             :method   => 'PUT',
             :parser   => Fog::Parsers::Storage::Google::CopyObject.new,
-            :path     => Google.escape(target_object_name)
+            :path     => Fog::Google.escape(target_object_name)
           })
         end
       end

--- a/lib/fog/google/requests/storage/copy_object.rb
+++ b/lib/fog/google/requests/storage/copy_object.rb
@@ -32,7 +32,7 @@ module Fog
             :host     => "#{target_bucket_name}.#{@host}",
             :method   => 'PUT',
             :parser   => Fog::Parsers::Storage::Google::CopyObject.new,
-            :path     => CGI.escape(target_object_name)
+            :path     => Google.escape(target_object_name)
           })
         end
       end

--- a/lib/fog/google/requests/storage/put_object.rb
+++ b/lib/fog/google/requests/storage/put_object.rb
@@ -32,7 +32,7 @@ module Fog
             :host       => "#{bucket_name}.#{@host}",
             :idempotent => true,
             :method     => 'PUT',
-            :path       => CGI.escape(object_name)
+            :path       => Google.escape(object_name)
           })
         end
       end

--- a/lib/fog/google/requests/storage/put_object.rb
+++ b/lib/fog/google/requests/storage/put_object.rb
@@ -32,7 +32,7 @@ module Fog
             :host       => "#{bucket_name}.#{@host}",
             :idempotent => true,
             :method     => 'PUT',
-            :path       => Google.escape(object_name)
+            :path       => Fog::Google.escape(object_name)
           })
         end
       end


### PR DESCRIPTION
Currently, fog-google uses `CGI.escape` when sanitizing the names of files to be uploaded to Google Cloud. This causes `my file.txt` to become `my+file.txt` . I copied over the method used in `Rackspace.escape` to allow whitespace characters in filenames.