### PR TITLE
Fix for regions test

### DIFF
--- a/test/integration/compute/test_regions.rb
+++ b/test/integration/compute/test_regions.rb
@@ -1,7 +1,7 @@
 require "helpers/integration_test_helper"
 
 class TestRegions < FogIntegrationTest
-  NAMES = %w(asia-east1 europe-west1 us-central1)
+  NAMES = %w(asia-east1 europe-west1 us-central1 us-central2)
 
   def setup
     @subject = Fog::Compute[:google].regions


### PR DESCRIPTION
Google added new DC and current test returns Failure:

TestRegions#test_all [/Users/mlazarov/projects/fog-google/test/integration/compute/test_regions.rb:11]:
Expected: 3
  Actual: 4

This pull request will fix it.