### PR TITLE
Update dns.rb to use v1 rather than v1beta1

### DIFF
--- a/lib/fog/google/dns.rb
+++ b/lib/fog/google/dns.rb
@@ -5,7 +5,7 @@ module Fog
       recognizes :app_name, :app_version, :google_client_email, :google_key_location, :google_key_string,
                  :google_client, :google_json_key_location, :google_json_key_string
 
-      GOOGLE_DNS_API_VERSION     = 'v1beta1'
+      GOOGLE_DNS_API_VERSION     = 'v1'
       GOOGLE_DNS_BASE_URL        = 'https://www.googleapis.com/dns/'
       GOOGLE_DNS_API_SCOPE_URLS  = %w(https://www.googleapis.com/auth/ndev.clouddns.readwrite)
 


### PR DESCRIPTION
v1beta1 will deprecated eventually lets move to v1. This should be a no-op.