### PR TITLE
Updating dns comment links to v1

### DIFF
--- a/lib/fog/google/models/dns/change.rb
+++ b/lib/fog/google/models/dns/change.rb
@@ -6,7 +6,7 @@ module Fog
       ##
       # Represents a Change resource
       #
-      # @see https://developers.google.com/cloud-dns/api/v1beta1/changes
+      # @see https://developers.google.com/cloud-dns/api/v1/changes
       class Change < Fog::Model
         identity :id
 

--- a/lib/fog/google/models/dns/project.rb
+++ b/lib/fog/google/models/dns/project.rb
@@ -6,7 +6,7 @@ module Fog
       ##
       # Represents a Project resource
       #
-      # @see https://developers.google.com/cloud-dns/api/v1beta1/projects
+      # @see https://developers.google.com/cloud-dns/api/v1/projects
       class Project < Fog::Model
         identity :id
 

--- a/lib/fog/google/models/dns/record.rb
+++ b/lib/fog/google/models/dns/record.rb
@@ -6,7 +6,7 @@ module Fog
       ##
       # Resource Record Sets resource
       #
-      # @see https://cloud.google.com/dns/api/v1beta1/resourceRecordSets
+      # @see https://cloud.google.com/dns/api/v1/resourceRecordSets
       class Record < Fog::Model
         identity :name
 

--- a/lib/fog/google/models/dns/zone.rb
+++ b/lib/fog/google/models/dns/zone.rb
@@ -6,7 +6,7 @@ module Fog
       ##
       # Managed Zone resource
       #
-      # @see https://developers.google.com/cloud-dns/api/v1beta1/managedZones
+      # @see https://developers.google.com/cloud-dns/api/v1/managedZones
       class Zone < Fog::Model
         identity :id
 

--- a/lib/fog/google/requests/dns/create_change.rb
+++ b/lib/fog/google/requests/dns/create_change.rb
@@ -4,7 +4,7 @@ module Fog
       ##
       # Atomically updates a ResourceRecordSet collection.
       #
-      # @see https://cloud.google.com/dns/api/v1beta1/changes/create
+      # @see https://cloud.google.com/dns/api/v1/changes/create
       class Real
         def create_change(zone_name_or_id, additions = [], deletions = [])
           api_method = @dns.changes.create

--- a/lib/fog/google/requests/dns/create_managed_zone.rb
+++ b/lib/fog/google/requests/dns/create_managed_zone.rb
@@ -5,7 +5,7 @@ module Fog
       ##
       # Creates a new Managed Zone.
       #
-      # @see https://developers.google.com/cloud-dns/api/v1beta1/managedZones/create
+      # @see https://developers.google.com/cloud-dns/api/v1/managedZones/create
       class Real
         def create_managed_zone(name, dns_name, description)
           api_method = @dns.managed_zones.create

--- a/lib/fog/google/requests/dns/delete_managed_zone.rb
+++ b/lib/fog/google/requests/dns/delete_managed_zone.rb
@@ -4,7 +4,7 @@ module Fog
       ##
       # Deletes a previously created Managed Zone.
       #
-      # @see https://developers.google.com/cloud-dns/api/v1beta1/managedZones/delete
+      # @see https://developers.google.com/cloud-dns/api/v1/managedZones/delete
       class Real
         def delete_managed_zone(name_or_id)
           api_method = @dns.managed_zones.delete

--- a/lib/fog/google/requests/dns/get_change.rb
+++ b/lib/fog/google/requests/dns/get_change.rb
@@ -4,7 +4,7 @@ module Fog
       ##
       # Fetches the representation of an existing Change.
       #
-      # @see https://developers.google.com/cloud-dns/api/v1beta1/changes/get
+      # @see https://developers.google.com/cloud-dns/api/v1/changes/get
       class Real
         def get_change(zone_name_or_id, identity)
           api_method = @dns.changes.get

--- a/lib/fog/google/requests/dns/get_managed_zone.rb
+++ b/lib/fog/google/requests/dns/get_managed_zone.rb
@@ -4,7 +4,7 @@ module Fog
       ##
       # Fetches the representation of an existing Managed Zone.
       #
-      # @see https://developers.google.com/cloud-dns/api/v1beta1/managedZones/get
+      # @see https://developers.google.com/cloud-dns/api/v1/managedZones/get
       class Real
         def get_managed_zone(name_or_id)
           api_method = @dns.managed_zones.get

--- a/lib/fog/google/requests/dns/get_project.rb
+++ b/lib/fog/google/requests/dns/get_project.rb
@@ -5,7 +5,7 @@ module Fog
       # Fetches the representation of an existing Project. Use this method to look up the limits on the number of
       # resources that are associated with your project.
       #
-      # @see https://developers.google.com/cloud-dns/api/v1beta1/projects/get
+      # @see https://developers.google.com/cloud-dns/api/v1/projects/get
       class Real
         def get_project(identity)
           api_method = @dns.projects.get

--- a/lib/fog/google/requests/dns/list_changes.rb
+++ b/lib/fog/google/requests/dns/list_changes.rb
@@ -4,7 +4,7 @@ module Fog
       ##
       # Enumerates the list of Changes.
       #
-      # @see https://developers.google.com/cloud-dns/api/v1beta1/changes/list
+      # @see https://developers.google.com/cloud-dns/api/v1/changes/list
       class Real
         def list_changes(zone_name_or_id)
           api_method = @dns.changes.list

--- a/lib/fog/google/requests/dns/list_managed_zones.rb
+++ b/lib/fog/google/requests/dns/list_managed_zones.rb
@@ -4,7 +4,7 @@ module Fog
       ##
       # Enumerates Managed Zones that have been created but not yet deleted.
       #
-      # @see hhttps://developers.google.com/cloud-dns/api/v1beta1/managedZones/list
+      # @see hhttps://developers.google.com/cloud-dns/api/v1/managedZones/list
       class Real
         def list_managed_zones()
           api_method = @dns.managed_zones.list

--- a/lib/fog/google/requests/dns/list_resource_record_sets.rb
+++ b/lib/fog/google/requests/dns/list_resource_record_sets.rb
@@ -4,7 +4,7 @@ module Fog
       ##
       # Enumerates Resource Record Sets that have been created but not yet deleted.
       #
-      # @see https://developers.google.com/cloud-dns/api/v1beta1/resourceRecordSets/list
+      # @see https://developers.google.com/cloud-dns/api/v1/resourceRecordSets/list
       class Real
         def list_resource_record_sets(zone_name_or_id, options = {})
           api_method = @dns.resource_record_sets.list


### PR DESCRIPTION
Tiny doc fix. Noticed that DNS API reference links are now outdated.
Updated them to v1 and made sure they can be opened.
