### PR TITLE
Actually limit ruby version. Up version to 0.1.1

### DIFF
--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  # As of 0.1.1
+  spec.required_ruby_version = '>= 2.0'
+
   spec.add_dependency 'fog-core'
   spec.add_dependency 'fog-json'
   spec.add_dependency 'fog-xml'

--- a/lib/fog/google/version.rb
+++ b/lib/fog/google/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Google
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
Realized when testing https://github.com/fog/fog-google/issues/72.