### PR TITLE
Added .editorconfig for easier editing.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# For more info on EditorConfig, see: http://EditorConfig.org
+
+root = true
+
+[*.gemspec,*.rb,Gemfile,Rakefile]
+indent_style = space
+indent_size = 2
+
+[*.yml,*.yaml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Editor Config allows local per-project configuration to be expressed in a single
file, which makes it easy for one to work across many repos with many projects,
each of which may have its own preferred indentation, spacing, EOL, encoding,
etc. styles.

This change adds a 2-space indent for Ruby and YAML files; other rules can be
added quite easily. The file has a pointer to the project's homepage which
explains how to install editor-specific plugins to handle this config and how
to extend this config further.