### PR TITLE
Consistent alias defintions

### DIFF
--- a/examples/l7_load_balance.rb
+++ b/examples/l7_load_balance.rb
@@ -49,8 +49,8 @@ def test
                                          ]
                                        }],
                                        :hostRules => [{ "hosts" => ["*"], "pathMatcher" => "pathmatcher" }],
-                                       :defaultService => backend_service1.self_link)
+                                       :default_service => backend_service1.self_link)
   proxy = connection.target_http_proxies.create(:name => "fog-l7-proxy",
-                                                :urlMap => url_map.self_link)
+                                                :url_map => url_map.self_link)
   fwd_rle = connection.global_forwarding_rules.create(:name => "fog-l7-fwd-rule", :target => proxy.self_link)
 end

--- a/lib/fog/google/models/compute/target_http_proxy.rb
+++ b/lib/fog/google/models/compute/target_http_proxy.rb
@@ -18,7 +18,7 @@ module Fog
 
           options = {
             "description" => description,
-            "urlMap"      => urlMap
+            "urlMap"      => url_map
           }
 
           data = service.insert_target_http_proxy(name, options).body

--- a/lib/fog/google/models/compute/target_http_proxy.rb
+++ b/lib/fog/google/models/compute/target_http_proxy.rb
@@ -11,7 +11,7 @@ module Fog
         attribute :id, :aliases => "id"
         attribute :creation_timestamp, :aliases => "creationTimestamp"
         attribute :description, :aliases => "description"
-        attribute :urlMap, :aliases => ["urlMap", :url_map]
+        attribute :url_map, :aliases => "urlMap"
 
         def save
           requires :name

--- a/lib/fog/google/models/compute/target_instance.rb
+++ b/lib/fog/google/models/compute/target_instance.rb
@@ -54,19 +54,18 @@ module Fog
         def reload
           requires :name, :zone
 
-          return unless data = begin
-            collection.get(name, zone)
+          begin
+            data = collection.get(name, zone)
+            new_attributes = data.attributes
+            merge_attributes(new_attributes)
+            return self
           rescue Excon::Errors::SocketError
-            nil
+            return nil
           end
-
-          new_attributes = data.attributes
-          merge_attributes(new_attributes)
-          self
         end
 
         RUNNING_STATE = "READY"
       end
     end
-   end
   end
+end

--- a/lib/fog/google/models/compute/url_map.rb
+++ b/lib/fog/google/models/compute/url_map.rb
@@ -21,11 +21,11 @@ module Fog
           requires :name, :default_service
 
           options = {
-            "defaultService" => defaultService,
+            "defaultService" => default_service,
             "description" => description,
             "fingerprint" => fingerprint,
-            "hostRules" => hostRules,
-            "pathMatchers" => pathMatchers,
+            "hostRules" => host_rules,
+            "pathMatchers" => path_matchers,
             "tests" => tests
           }
 

--- a/lib/fog/google/models/compute/url_map.rb
+++ b/lib/fog/google/models/compute/url_map.rb
@@ -18,7 +18,7 @@ module Fog
         attribute :tests, :aliases => "tests"
 
         def save
-          requires :name, :defaultService
+          requires :name, :default_service
 
           options = {
             "defaultService" => defaultService,

--- a/lib/fog/google/models/compute/url_map.rb
+++ b/lib/fog/google/models/compute/url_map.rb
@@ -7,13 +7,13 @@ module Fog
         identity :name
 
         attribute :kind, :aliases => "kind"
-        attribute :creationTimestamp, :aliases => "creation_timestamp"
-        attribute :defaultService, :aliases => ["default_service", :default_service]
+        attribute :creation_timestamp, :aliases => "creationTimestamp"
+        attribute :default_service, :aliases => "defaultService"
         attribute :description, :aliases => "description"
         attribute :fingerprint, :aliases => "fingerprint"
-        attribute :hostRules, :aliases => "host_rules"
+        attribute :host_rules, :aliases => "hostRules"
         attribute :id, :aliases => "id"
-        attribute :pathMatchers, :aliases => "path_matchers"
+        attribute :path_matchers, :aliases => "pathMatchers"
         attribute :self_link, :aliases => "selfLink"
         attribute :tests, :aliases => "tests"
 

--- a/lib/fog/google/models/storage/file.rb
+++ b/lib/fog/google/models/storage/file.rb
@@ -28,11 +28,7 @@ module Fog
         end
 
         def body
-          attributes[:body] ||= if last_modified && (file = collection.get(identity))
-                                  file.body
-                                else
-                                  ""
-          end
+          attributes[:body] ||= last_modified && (file = collection.get(identity)) ? file.body : ""
         end
 
         def body=(new_body)

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -62,7 +62,7 @@ def create_test_url_map(connection)
   backend_service = create_test_backend_service(connection)
   url_map = connection.url_maps.create({
                                          :name => "fog-test-url-map-#{random_string}",
-                                         :defaultService => backend_service.self_link
+                                         :default_service => backend_service.self_link
                                        })
 end
 
@@ -82,7 +82,7 @@ def create_test_target_http_proxy(connection)
   url_map = create_test_url_map(connection)
   proxy = connection.target_http_proxies.create({
                                                   :name => "fog-test-target-http-proxy-#{random_string}",
-                                                  :urlMap => url_map.self_link
+                                                  :url_map => url_map.self_link
                                                 })
 end
 
@@ -103,7 +103,7 @@ def create_test_target_pool(connection, region)
   target_pool = connection.target_pools.create({
                                                  :name => "fog-test-target-pool-#{random_string}",
                                                  :region => region,
-                                                 :healthChecks => [http_health_check.self_link],
+                                                 :health_checks => [http_health_check.self_link],
                                                  :instances => [instance.self_link]\
                                                })
 end


### PR DESCRIPTION
Fixes #34.

Also goes up and cleans up some rubocop warnings in `models/`