### PR TITLE
Storage delete_object fix + new storage example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.a
 mkmf.log
 .ruby-version
+.idea/

--- a/examples/storage.rb
+++ b/examples/storage.rb
@@ -1,0 +1,27 @@
+# This example needs google_storage_access_key_id: and google_storage_secret_access_key to be set in ~/.fog
+# One can request those keys via Google Developers console in:
+# Storage -> Storage -> Settings -> "Interoperability" tab -> "Create a new key"
+
+def test
+  connection = Fog::Storage::Google.new
+
+  puts 'Put a bucket...'
+  puts '----------------'
+  connection.put_bucket('fog-smoke-test')
+
+  puts 'Get the bucket...'
+  puts '-----------------'
+  connection.get_bucket('fog-smoke-test')
+
+  puts 'Put a test file...'
+  puts '---------------'
+  connection.put_object('fog-smoke-test', 'my file' ,'THISISATESTFILE')
+
+  puts 'Delete the test file...'
+  puts '---------------'
+  connection.delete_object('fog-smoke-test', 'my file')
+
+  puts 'Delete the bucket...'
+  puts '------------------'
+  connection.delete_bucket('fog-smoke-test')
+end

--- a/lib/fog/google/requests/storage/delete_object.rb
+++ b/lib/fog/google/requests/storage/delete_object.rb
@@ -17,7 +17,7 @@ module Fog
                   :host       => "#{bucket_name}.#{@host}",
                   :idempotent => true,
                   :method     => "DELETE",
-                  :path       => CGI.escape(object_name))
+                  :path       => Fog::Google.escape(object_name))
         end
       end
 


### PR DESCRIPTION
#56 implemented a new escape method for create_object and copy_object, but didn't change the
delete_object method, leading to a situation when we can create a file with whitespace in it, but cannot actually delete it.

Additionally, added a new Google storage usage example.