### PR TITLE
Refactoring the Rakefile into tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,43 +1,19 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+require 'rubygems'
+require 'bundler/setup'
 
-Rake::TestTask.new do |t|
-  t.libs << "test"
-  t.pattern = File.join("test", "**", "test_*.rb")
+# Immediately sync all stdout so that tools like buildbot can
+# immediately load in the output.
+$stdout.sync = true
+$stderr.sync = true
+
+# Load all the rake tasks from the "tasks" folder. This folder
+# allows us to nicely separate rake tasks into individual files
+# based on their role, which makes development and debugging easier
+# than one monolithic file.
+task_dir = File.expand_path('../tasks', __FILE__)
+Dir["#{task_dir}/**/*.rake"].each do |task_file|
+  load task_file
 end
 
-desc "Default Task"
-task :default => ["test:travis"]
-
-namespace :test do
-  mock = ENV["FOG_MOCK"] || "true"
-  task :travis do
-    sh("export FOG_MOCK=#{mock} && bundle exec shindont")
-  end
-end
-
-namespace :google do
-  namespace :smoke do
-    desc "Smoke tests for Google Compute Engine."
-    task :compute do
-      puts "These smoke tests assume you have a file at ~/.fog which has your credentials for connecting to GCE."
-
-      Dir.glob("./examples/*.rb").each do |file|
-        puts "Running #{file}:"
-        require file
-        test
-      end
-    end
-  end
-end
-
-# From http://erniemiller.org/2014/02/05/7-lines-every-gems-rakefile-should-have/
-# with some modification.
-task :console do
-  require "irb"
-  require "irb/completion"
-  require "fog/google"
-  Fog.credential = :test
-  ARGV.clear
-  IRB.start
-end
+desc 'Default Task'
+task default: 'test:travis'

--- a/tasks/bundler.rake
+++ b/tasks/bundler.rake
@@ -1,0 +1,3 @@
+# This installs the tasks that help with gem creation and
+# publishing.
+Bundler::GemHelper.install_tasks

--- a/tasks/console.rake
+++ b/tasks/console.rake
@@ -1,0 +1,12 @@
+# From http://erniemiller.org/2014/02/05/7-lines-every-gems-rakefile-should-have/
+# with some modification.
+
+desc 'Project IRB console'
+task :console do
+  require 'irb'
+  require 'irb/completion'
+  require 'fog/google'
+  Fog.credential = :test
+  ARGV.clear
+  IRB.start
+end

--- a/tasks/smoke.rake
+++ b/tasks/smoke.rake
@@ -1,0 +1,15 @@
+desc 'Run smoke tests from examples directory'
+namespace :google do
+  namespace :smoke do
+    desc 'Smoke tests for Google Compute Engine.'
+    task :compute do
+      puts 'These smoke tests assume you have a file at ~/.fog which has your credentials for connecting to GCE.'
+
+      Dir.glob('./examples/*.rb').each do |file|
+        puts "Running #{file}:"
+        require file
+        test
+      end
+    end
+  end
+end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,0 +1,13 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.libs << 'test'
+  t.pattern = File.join('test', '**', 'test_*.rb')
+end
+
+namespace :test do
+  mock = ENV['FOG_MOCK'] || 'true'
+  task :travis do
+    sh("export FOG_MOCK=#{mock} && bundle exec shindont")
+  end
+end


### PR DESCRIPTION
Before adding rubocop task, decided to refactor the rakefile into separate easily maintainable tasks.
What do you think about this?

/CC @icco @plribeiro3000