### PR TITLE
Removing <=1.9 rules from gemspec

### DIFF
--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -32,9 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"
-
-  if RUBY_VERSION.to_f > 1.9
-    spec.add_development_dependency "coveralls"
-    spec.add_development_dependency "rubocop"
-  end
+  spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "rubocop"
 end


### PR DESCRIPTION
We still had Ruby 1.9 version fixup in the gemspec for rubocop and coveralls.
Considering the gemspec now doesn't allow <2.0, I presume we can remove it.
