### PR TITLE
Update fog-google.gemspec

### DIFF
--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -25,9 +25,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fog-core"
   spec.add_dependency "fog-json"
   spec.add_dependency "fog-xml"
+  spec.add_dependency "google-api-client", "< 0.9", ">= 0.6.2"
+
 
   # TODO: Upgrade to 0.9, which is not compatible.
-  spec.add_development_dependency "google-api-client", "< 0.9", ">= 0.6.2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "shindo"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
- `google-api-client` is required for fog-google to work, otherwise a warning
```
[fog][WARNING] Please install the google-api-client gem before using this provider
```
get thrown. This PR moves it from a development dependency to a dependency so it happens in the background.