### PR TITLE
Add support for partial content to support range header.

### DIFF
--- a/lib/fog/google/requests/storage/get_object.rb
+++ b/lib/fog/google/requests/storage/get_object.rb
@@ -42,7 +42,7 @@ module Fog
 
           params[:response_block] = Proc.new if block_given?
 
-          request(params.merge!(:expects        => 200,
+          request(params.merge!(:expects        => [200, 206],
                                 :host           => "#{bucket_name}.#{@host}",
                                 :idempotent     => true,
                                 :method         => "GET",

--- a/lib/fog/google/requests/storage/head_object.rb
+++ b/lib/fog/google/requests/storage/head_object.rb
@@ -33,7 +33,7 @@ module Fog
           headers["If-Modified-Since"] = Fog::Time.at(options["If-Modified-Since"].to_i).to_date_header if options["If-Modified-Since"]
           headers["If-Unmodified-Since"] = Fog::Time.at(options["If-Unmodified-Since"].to_i).to_date_header if options["If-Modified-Since"]
           headers.merge!(options)
-          request(:expects  => 200,
+          request(:expects  => [200, 206],
                   :headers  => headers,
                   :host     => "#{bucket_name}.#{@host}",
                   :method   => "HEAD",


### PR DESCRIPTION
The gem seems to support the http `Range:` header, however it doesn't accept the `206` response from google, which is required. (206 = Partial Content)

The following PR adds basic support for accepting `206 Partial Content`, allowing the `Range` header to be used to get objects from GCS.