### PR TITLE
Update monitoring for v2beta2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Fog implements [v1](https://cloud.google.com/dns/api/v1/) of the Google Cloud DN
 
 ## Monitoring
 
-Fog implements [v2beta1](https://cloud.google.com/monitoring/v2beta2/) of the Google Cloud Monitoring API. This is a currently deprecated version of the API. Pull requests for updates would be greatly appreciated.
+Fog implements [v2beta2](https://cloud.google.com/monitoring/v2beta2/) of the Google Cloud Monitoring API. As of 2016-03-15, we believe Fog for Google Cloud Monitoring is feature complete. We are always looking for people to improve our code and test coverage, so please [file issues](https://github.com/fog/fog-google/issues) for any anomalies you see or features you would like.
+
+ 
 
 ## Installation
 

--- a/examples/monitoring/metric_descriptors.rb
+++ b/examples/monitoring/metric_descriptors.rb
@@ -1,4 +1,11 @@
-require "fog"
+# All examples presume that you have a ~/.fog credentials file set up.
+# # More info on it can be found here: http://fog.io/about/getting_started.html
+#
+require "bundler"
+Bundler.require(:default, :development)
+# Uncomment this if you want to make real requests to GCE (you _will_ be billed!)
+# WebMock.disable!
+#
 
 def test
   connection = Fog::Google::Monitoring.new

--- a/examples/monitoring/metric_descriptors.rb
+++ b/examples/monitoring/metric_descriptors.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require "fog"
 
 def test
   connection = Fog::Google::Monitoring.new

--- a/examples/monitoring/metric_descriptors.rb
+++ b/examples/monitoring/metric_descriptors.rb
@@ -1,11 +1,17 @@
+require 'fog'
+
 def test
   connection = Fog::Google::Monitoring.new
 
   puts "Listing all MetricDescriptors..."
   puts "--------------------------------"
-  connection.metric_descriptors
+  md = connection.metric_descriptors
+  puts "Number of all metric descriptors: #{md.length}"
 
-  puts "Listing all MetricDescriptors related to Google Compute Engine..."
+  puts "\nListing all MetricDescriptors related to Google Compute Engine..."
   puts "-----------------------------------------------------------------"
-  connection.metric_descriptors.all(:query => "compute")
+  md = connection.metric_descriptors.all(:query => "compute")
+  puts "Number of compute metric descriptors: #{md.length}"
 end
+
+test

--- a/examples/monitoring/timeseries_collection.rb
+++ b/examples/monitoring/timeseries_collection.rb
@@ -1,4 +1,10 @@
-require "fog"
+# All examples presume that you have a ~/.fog credentials file set up.
+# # More info on it can be found here: http://fog.io/about/getting_started.html
+#
+require "bundler"
+Bundler.require(:default, :development)
+# Uncomment this if you want to make real requests to GCE (you _will_ be billed!)
+# WebMock.disable!
 
 def test
   connection = Fog::Google::Monitoring.new

--- a/examples/monitoring/timeseries_collection.rb
+++ b/examples/monitoring/timeseries_collection.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require "fog"
 
 def test
   connection = Fog::Google::Monitoring.new

--- a/examples/monitoring/timeseries_collection.rb
+++ b/examples/monitoring/timeseries_collection.rb
@@ -1,15 +1,21 @@
+require 'fog'
+
 def test
   connection = Fog::Google::Monitoring.new
 
   puts "Listing all Timeseries for the metric compute.googleapis.com/instance/uptime..."
   puts "-------------------------------------------------------------------------------"
-  connection.timeseries_collection.all("compute.googleapis.com/instance/uptime",
-                                       DateTime.now.rfc3339)
+  tc = connection.timeseries_collection.all("compute.googleapis.com/instance/uptime",
+                                            DateTime.now.rfc3339)
+  puts "Number of matches: #{tc.length}"
 
-  puts "Listing all Timeseries for the metric compute.googleapis.com/instance/uptime &"
+  puts "\nListing all Timeseries for the metric compute.googleapis.com/instance/uptime &"
   puts "the region us-central1..."
   puts "------------------------------------------------------------------------------"
-  connection.timeseries_collection.all("compute.googleapis.com/instance/uptime",
-                                       DateTime.now.rfc3339,
-                                       :labels => "cloud.googleapis.com/location=~us-central1.*")
+  tc = connection.timeseries_collection.all("compute.googleapis.com/instance/uptime",
+                                            DateTime.now.rfc3339,
+                                            :labels => "cloud.googleapis.com/location=~us-central1.*")
+  puts "Number of matches: #{tc.length}"
 end
+
+test

--- a/examples/monitoring/timeseries_descriptors.rb
+++ b/examples/monitoring/timeseries_descriptors.rb
@@ -1,4 +1,10 @@
-require "fog"
+# All examples presume that you have a ~/.fog credentials file set up.
+# # More info on it can be found here: http://fog.io/about/getting_started.html
+#
+require "bundler"
+Bundler.require(:default, :development)
+# Uncomment this if you want to make real requests to GCE (you _will_ be billed!)
+# WebMock.disable!
 
 def test
   connection = Fog::Google::Monitoring.new

--- a/examples/monitoring/timeseries_descriptors.rb
+++ b/examples/monitoring/timeseries_descriptors.rb
@@ -1,15 +1,21 @@
+require 'fog'
+
 def test
   connection = Fog::Google::Monitoring.new
 
   puts "Listing all TimeseriesDescriptors for the metric compute.googleapis.com/instance/uptime..."
   puts "------------------------------------------------------------------------------------------"
-  connection.timeseries_descriptors.all("compute.googleapis.com/instance/uptime",
-                                        DateTime.now.rfc3339)
+  td = connection.timeseries_descriptors.all("compute.googleapis.com/instance/uptime",
+                                             DateTime.now.rfc3339)
+  puts "Number of matches: #{td.length}"
 
   puts "Listing all TimeseriesDescriptors for the metric compute.googleapis.com/instance/uptime &"
   puts "the region us-central1..."
   puts "-----------------------------------------------------------------------------------------"
-  connection.timeseries_descriptors.all("compute.googleapis.com/instance/uptime",
-                                        DateTime.now.rfc3339,
-                                        :labels => "cloud.googleapis.com/location=~us-central1.*")
+  td = connection.timeseries_descriptors.all("compute.googleapis.com/instance/uptime",
+                                             DateTime.now.rfc3339,
+                                             :labels => "cloud.googleapis.com/location=~us-central1.*")
+  puts "Number of matches: #{td.length}"
 end
+
+test

--- a/examples/monitoring/timeseries_descriptors.rb
+++ b/examples/monitoring/timeseries_descriptors.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require "fog"
 
 def test
   connection = Fog::Google::Monitoring.new

--- a/lib/fog/google/models/monitoring/metric_descriptor.rb
+++ b/lib/fog/google/models/monitoring/metric_descriptor.rb
@@ -6,7 +6,7 @@ module Fog
       ##
       # A metricDescriptor defines the name, label keys, and data type of a particular metric.
       #
-      # @see https://developers.google.com/cloud-monitoring/v2beta1/metricDescriptors
+      # @see https://cloud.google.com/monitoring/v2beta2/metricDescriptors#resource
       class MetricDescriptor < Fog::Model
         identity :name
 

--- a/lib/fog/google/monitoring.rb
+++ b/lib/fog/google/monitoring.rb
@@ -5,9 +5,9 @@ module Fog
       recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
                  :app_name, :app_version, :google_json_key_location, :google_json_key_string
 
-      GOOGLE_MONITORING_API_VERSION    = "v2beta1"
+      GOOGLE_MONITORING_API_VERSION    = "v2beta2"
       GOOGLE_MONITORING_BASE_URL       = "https://www.googleapis.com/cloudmonitoring/"
-      GOOGLE_MONITORING_API_SCOPE_URLS = %w(https://www.googleapis.com/auth/monitoring.readonly)
+      GOOGLE_MONITORING_API_SCOPE_URLS = %w(https://www.googleapis.com/auth/monitoring)
 
       ##
       # MODELS

--- a/lib/fog/google/monitoring.rb
+++ b/lib/fog/google/monitoring.rb
@@ -5,7 +5,7 @@ module Fog
       recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
                  :app_name, :app_version, :google_json_key_location, :google_json_key_string
 
-      GOOGLE_MONITORING_API_VERSION    = "v2beta2"
+      GOOGLE_MONITORING_API_VERSION    = "v2beta2".freeze
       GOOGLE_MONITORING_BASE_URL       = "https://www.googleapis.com/cloudmonitoring/"
       GOOGLE_MONITORING_API_SCOPE_URLS = %w(https://www.googleapis.com/auth/monitoring)
 

--- a/lib/fog/google/requests/monitoring/list_metric_descriptors.rb
+++ b/lib/fog/google/requests/monitoring/list_metric_descriptors.rb
@@ -5,7 +5,7 @@ module Fog
       # List metric descriptors that match the query. If the query is not set, then all of the metric descriptors
       # will be returned.
       #
-      # @see https://developers.google.com/cloud-monitoring/v2beta1/metricDescriptors/list
+      # @see https://cloud.google.com/monitoring/v2beta2/metricDescriptors/list
       class Real
         def list_metric_descriptors(options = {})
           api_method = @monitoring.metric_descriptors.list


### PR DESCRIPTION
Only real update was changing the API version to `v2beta2` and updating the name of the scope, otherwise, no real changes.