### PR TITLE
Add list_images method to return current, non-deprecated images

### DIFF
--- a/examples/get_list_images.rb
+++ b/examples/get_list_images.rb
@@ -15,6 +15,12 @@ def test
   raise "Could not LIST the images" unless images
   puts images.inspect
 
+  puts "Listing current (non-deprecated) images in all projects..."
+  puts "---------------------------------"
+  images = connection.images.current
+  raise "Could not LIST the images" unless images
+  puts images.inspect
+
   puts "Fetching a single image from a global project..."
   puts "------------------------------------------------"
   img = connection.images.get("debian-7-wheezy-v20151104")

--- a/examples/get_list_images.rb
+++ b/examples/get_list_images.rb
@@ -16,9 +16,9 @@ def test
   puts images.inspect
 
   puts "Listing current (non-deprecated) images in all projects..."
-  puts "---------------------------------"
+  puts "----------------------------------------------------------"
   images = connection.images.current
-  raise "Could not LIST the images" unless images
+  raise "Could not LIST current images" unless images
   puts images.inspect
 
   puts "Fetching a single image from a global project..."

--- a/lib/fog/compute/google/models/images.rb
+++ b/lib/fog/compute/google/models/images.rb
@@ -43,12 +43,10 @@ module Fog
 
         # Only return the non-deprecated list of images
         def current
-            data = []
-            all_images = self.all
-            all_images.each { |img|
-                data.push(img) unless img.deprecated
-            }
-            data
+          data = []
+          all_images = all
+          all_images.each { |img| data.push(img) unless img.deprecated }
+          data
         end
 
         def get(identity)

--- a/lib/fog/compute/google/models/images.rb
+++ b/lib/fog/compute/google/models/images.rb
@@ -41,6 +41,16 @@ module Fog
           load(data)
         end
 
+        # Only return the non-deprecated list of images
+        def current
+            data = []
+            all_images = self.all
+            all_images.each { |img|
+                data.push(img) unless img.deprecated
+            }
+            data
+        end
+
         def get(identity)
           # Search own project before global projects
           all_projects = [service.project] + global_projects


### PR DESCRIPTION
Currently, there are roughly 420 images across all GCE "official" image projects, but only about 20 that are not deprecated across the same set of projects.  I think most users will only want to see the "current" non-deprecated list.

