### PR TITLE
Update list of ACLs and change default private

### DIFF
--- a/lib/fog/google/models/storage/file.rb
+++ b/lib/fog/google/models/storage/file.rb
@@ -19,10 +19,12 @@ module Fog
         attribute :owner,               :aliases => 'Owner'
         attribute :storage_class,       :aliases => ['x-goog-storage-class', 'StorageClass']
 
+        # https://cloud.google.com/storage/docs/access-control#predefined-acl
+        VALID_ACLS = %w(project-private private public-read public-read-write authenticated-read bucket-owner-read bucket-owner-full-control).freeze
+
         def acl=(new_acl)
-          valid_acls = ['private', 'public-read', 'public-read-write', 'authenticated-read']
-          unless valid_acls.include?(new_acl)
-            raise ArgumentError.new("acl must be one of [#{valid_acls.join(', ')}]")
+          unless VALID_ACLS.include?(new_acl)
+            raise ArgumentError.new("acl must be one of [#{VALID_ACLS.join(', ')}]")
           end
           @acl = new_acl
         end
@@ -83,7 +85,7 @@ module Fog
           if new_public
             @acl = 'public-read'
           else
-            @acl = 'private'
+            @acl = 'project-private'
           end
           new_public
         end

--- a/lib/fog/google/version.rb
+++ b/lib/fog/google/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Google
-    VERSION = "0.1.1"
+    VERSION = "0.1.0"
   end
 end


### PR DESCRIPTION
Add all predefined ACLs currently listed on the Google docs:
https://cloud.google.com/storage/docs/access-control.

Also changed the `public=` method to choose "project-private" in
the false case. (This is the default bucket ACL policy).

I'm not sure there is a best `public=false` choice, but from what I could tell it would involve some updates to `fog` and potentially `paperclip` to allow passing through the desired ACL. 

These addresses issue #71.