### PR TITLE
Fog::Storage::GoogleJSON::File#url method signature fix

### DIFF
--- a/lib/fog/storage/google_json/models/file.rb
+++ b/lib/fog/storage/google_json/models/file.rb
@@ -133,9 +133,10 @@ module Fog
           true
         end
 
-        def url
+        # params[:expires] : Eg: Time.now to integer value.
+        def url(expires)
           requires :key
-          collection.get_https_url(key)
+          collection.get_https_url(key, expires)
         end
 
         private

--- a/test/integration/storage/test_files.rb
+++ b/test/integration/storage/test_files.rb
@@ -49,7 +49,7 @@ class TestFiles < FogIntegrationTest
   end
 
   def test_get_https_url
-    https_url = @directory.files.get_https_url("fog-testfile", 1000)
+    https_url = @directory.files.get_https_url("fog-testfile", (Time.now + 1.minute).to_i)
     assert_match(/https/, https_url)
     assert_match(/fog-smoke-test/, https_url)
     assert_match(/fog-testfile/, https_url)


### PR DESCRIPTION
I'm not sure how someone missed this. When I was trying to setup CarrierWave and fog-google I ran into the arguments 1 for 0 error. After patching this method CarrierWave is working fine and also I ran the storage integration tests after making this change.