### PR TITLE
Add initial support for Google Pubsub

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,19 @@ Fog implements [v1](https://cloud.google.com/dns/api/v1/) of the Google Cloud DN
 
 Fog implements [v2beta2](https://cloud.google.com/monitoring/v2beta2/) of the Google Cloud Monitoring API. As of 2016-03-15, we believe Fog for Google Cloud Monitoring is feature complete. We are always looking for people to improve our code and test coverage, so please [file issues](https://github.com/fog/fog-google/issues) for any anomalies you see or features you would like.
 
- 
+## Pubsub
 
+Note: You **must** have a version of google-api-client > 0.8.5 to use the Pub/Sub API; previous versions will not work.
+
+Fog mostly implements [v1](https://cloud.google.com/pubsub/reference/rest/) of the Google Cloud Pub/Sub API; however some less common API methods are missing. Pull requests for additions would be greatly appreciated.
+ 
 ## Installation
 
 Add the following two lines to your application's `Gemfile`:
 
 ```ruby
 gem 'fog-google'
-gem 'google-api-client', '< 0.9', '>= 0.6.2'
+gem 'google-api-client', '~> 0.8.6'
 ```
 
 And then execute:

--- a/examples/pubsub/subscriptions.rb
+++ b/examples/pubsub/subscriptions.rb
@@ -1,0 +1,54 @@
+# All examples presume that you have a ~/.fog credentials file set up.
+# # More info on it can be found here: http://fog.io/about/getting_started.html
+#
+require "bundler"
+Bundler.require(:default, :development)
+# Uncomment this if you want to make real requests to GCE (you _will_ be billed!)
+# WebMock.disable!
+
+def test
+  connection = Fog::Google::Pubsub.new
+
+  puts "Creating a topic to subscribe to"
+  puts "--------------------------------"
+  topic = connection.topics.create(:name => "projects/#{connection.project}/topics/#{Fog::Mock.random_letters(16)}")
+
+  puts "Creating a subscription"
+  puts "-----------------------"
+  subscription = connection.subscriptions.create(:name => "projects/#{connection.project}/subscriptions/#{Fog::Mock.random_letters(16)}", :topic => topic)
+
+  puts "Getting a subscription"
+  puts "----------------------"
+  connection.subscriptions.get(subscription.name)
+
+  puts "Listing all subscriptions"
+  puts "-------------------------"
+  connection.subscriptions.all
+
+  puts "Publishing to topic"
+  puts "-------------------"
+  topic.publish(["test message"])
+
+  puts "Pulling from subscription"
+  puts "-------------------------"
+
+  msgs = []
+  msgs = subscription.pull while msgs.empty?
+
+  puts "Acknowledging pulled messages"
+  puts "-----------------------------"
+  subscription.acknowledge(msgs)
+
+  # Alternatively, received messages themselves can be acknowledged
+  msgs.each(&:acknowledge)
+
+  puts "Deleting the subscription"
+  puts "-------------------------"
+  subscription.destroy
+
+  puts "Deleting the topic subscribed to"
+  puts "--------------------------------"
+  topic.destroy
+end
+
+test

--- a/examples/pubsub/topics.rb
+++ b/examples/pubsub/topics.rb
@@ -1,0 +1,33 @@
+# All examples presume that you have a ~/.fog credentials file set up.
+# # More info on it can be found here: http://fog.io/about/getting_started.html
+#
+require "bundler"
+Bundler.require(:default, :development)
+# Uncomment this if you want to make real requests to GCE (you _will_ be billed!)
+# WebMock.disable!
+
+def test
+  connection = Fog::Google::Pubsub.new
+
+  puts "Creating a topic"
+  puts "----------------"
+  topic = connection.topics.create(:name => "projects/#{connection.project}/topics/#{Fog::Mock.random_letters(16)}")
+
+  puts "Getting a topic"
+  puts "---------------"
+  connection.topics.get(topic.name)
+
+  puts "Listing all topics"
+  puts "------------------"
+  connection.topics.all
+
+  puts "Publishing to topic"
+  puts "-------------------"
+  topic.publish(["test message"])
+
+  puts "Delete the topic"
+  puts "----------------"
+  topic.destroy
+end
+
+test

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -20,14 +20,14 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # As of 0.1.1
-  spec.required_ruby_version = ">= 2.0"
+  spec.required_ruby_version = "~> 2.0"
 
   spec.add_dependency "fog-core"
   spec.add_dependency "fog-json"
   spec.add_dependency "fog-xml"
 
   # TODO: Upgrade to 0.9, which is not compatible.
-  spec.add_development_dependency "google-api-client", "< 0.9", ">= 0.6.2"
+  spec.add_development_dependency "google-api-client", "~> 0.8.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "shindo"
   spec.add_development_dependency "minitest"

--- a/lib/fog/google.rb
+++ b/lib/fog/google.rb
@@ -15,6 +15,7 @@ module Fog
   module Google
     autoload :Mock, File.expand_path("../google/mock", __FILE__)
     autoload :Monitoring, File.expand_path("../google/monitoring", __FILE__)
+    autoload :Pubsub, File.expand_path("../google/pubsub", __FILE__)
     autoload :Shared, File.expand_path("../google/shared", __FILE__)
     autoload :SQL, File.expand_path("../google/sql", __FILE__)
 
@@ -23,6 +24,7 @@ module Fog
     service(:compute, "Compute")
     service(:dns, "DNS")
     service(:monitoring, "Monitoring")
+    service(:pubsub, "Pubsub")
     service(:storage, "Storage")
     service(:sql, "SQL")
 

--- a/lib/fog/google/models/pubsub/received_message.rb
+++ b/lib/fog/google/models/pubsub/received_message.rb
@@ -1,0 +1,40 @@
+require "fog/core/model"
+
+module Fog
+  module Google
+    class Pubsub
+      # Represents a ReceivedMessage retrieved from a Google Pubsub
+      # subscription. Note that ReceivedMessages are immutable.
+      #
+      # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/pull#ReceivedMessage
+      class ReceivedMessage < Fog::Model
+        identity :ack_id, :aliases => "ackId"
+
+        attribute :message
+
+        def initialize(new_attributes = {})
+          # Here we secretly store the subscription name we were received on
+          # in order to support #acknowledge
+          attributes = new_attributes.clone
+          @subscription_name = attributes.delete(:subscription_name)
+          super(attributes)
+        end
+
+        # Acknowledges a message.
+        #
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/acknowledge
+        def acknowledge
+          requires :ack_id
+
+          service.acknowledge_subscription(@subscription_name, [ack_id])
+          nil
+        end
+
+        def reload
+          # Message is immutable - do nothing
+          Fog::Logger.warning("#reload called on immutable ReceivedMessage")
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/models/pubsub/subscription.rb
+++ b/lib/fog/google/models/pubsub/subscription.rb
@@ -1,0 +1,86 @@
+module Fog
+  module Google
+    class Pubsub
+      # Represents a Pubsub subscription resource
+      #
+      # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions
+      class Subscription < Fog::Model
+        identity :name
+        attribute :topic
+        attribute :push_config, :aliases => "pushConfig"
+        attribute :ack_deadline_seconds, :aliases => "ackDeadlineSeconds"
+
+        # Pulls from this subscription, returning any available messages. By
+        # default, this method returns immediately with up to 10 messages. The
+        # option 'return_immediately' allows the method to block until a
+        # message is received, or the remote service closes the connection.
+        #
+        # Note that this method automatically performs a base64 decode on the
+        # 'data' field.
+        #
+        # @param options [Hash] options to modify the pull request
+        # @option options [Boolean] :return_immediately If true, method returns
+        #   after checking for messages. Otherwise the method blocks until one
+        #   or more messages are available, or the connection is closed.
+        # @option options [Number] :max_messages maximum number of messages to
+        #   receive
+        # @return [Array<Fog::Google::Pubsub::ReceivedMessage>] list of
+        #   received messages, or an empty list if no messages are available.
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/pull
+        def pull(options = { :return_immediately => true, :max_messages => 10 })
+          requires :name
+
+          data = service.pull_subscription(name, options).body
+
+          return [] unless data.key?("receivedMessages")
+          # Turn into a list of ReceivedMessage, but ensure we perform a base64 decode first
+          data["receivedMessages"].map do |recv_message|
+            attrs = {
+              :service => service,
+              :subscription_name => name
+            }.merge(recv_message)
+
+            attrs["message"]["data"] = Base64.decode64(recv_message["message"]["data"]) if recv_message["message"].key?("data")
+            ReceivedMessage.new(attrs)
+          end
+        end
+
+        # Acknowledges a list of received messages for this subscription.
+        #
+        # @param messages [Array<Fog::Google::Pubsub::ReceivedMessage, #to_s>]
+        #   A list containing either ReceivedMessage instances to acknowledge,
+        #   or a list of ackIds (@see
+        #   https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/pull#ReceivedMessage).
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/acknowledge
+        def acknowledge(messages)
+          return if messages.empty?
+
+          ack_ids = messages.map { |m| m.is_a?(ReceivedMessage) ? m.ack_id : m.to_s }
+
+          service.acknowledge_subscription(name, ack_ids)
+          nil
+        end
+
+        # Save this instance on the remove service.
+        #
+        # @return [Fog::Google::Pubsub::Subscription] this instance
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
+        def save
+          requires :name, :topic
+
+          data = service.create_subscription(name, topic, push_config, ack_deadline_seconds).body
+          merge_attributes(data)
+        end
+
+        # Deletes this subscription on the remote service.
+        #
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
+        def destroy
+          requires :name
+
+          service.delete_subscription(name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/models/pubsub/subscriptions.rb
+++ b/lib/fog/google/models/pubsub/subscriptions.rb
@@ -1,0 +1,32 @@
+require "fog/core/collection"
+require "fog/google/models/pubsub/subscription"
+
+module Fog
+  module Google
+    class Pubsub
+      class Subscriptions < Fog::Collection
+        model Fog::Google::Pubsub::Subscription
+
+        # Lists all subscriptions that exist on the project.
+        #
+        # @return [Array<Fog::Google::Pubsub::Subscription>] list of
+        #   subscriptions
+        def all
+          data = service.list_subscriptions.body["subscriptions"] || []
+          load(data)
+        end
+
+        # Retrieves a subscription by name
+        #
+        # @param subscription_name [String] name of subscription to retrieve
+        # @return [Fog::Google::Pubsub::Topic] topic found, or nil if not found
+        def get(subscription_name)
+          subscription = service.get_subscription(subscription_name).body
+          new(subscription)
+        rescue Fog::Errors::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/models/pubsub/topic.rb
+++ b/lib/fog/google/models/pubsub/topic.rb
@@ -1,0 +1,72 @@
+require "fog/core/model"
+
+module Fog
+  module Google
+    class Pubsub
+      # Represents a Pubsub topic resource
+      #
+      # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics#Topic
+      class Topic < Fog::Model
+        identity :name
+
+        # Creates this topic resource on the service.
+        #
+        # @return [Fog::Google::Pubsub::Topic] this instance
+        def create
+          requires :name
+
+          service.create_topic(name)
+          self
+        end
+
+        # Deletes this topic resource on the service.
+        #
+        # @return [Fog::Google::Pubsub::Topic] this instance
+        def destroy
+          requires :name
+
+          service.delete_topic(name)
+          self
+        end
+
+        # Publish a message to this topic. This method will automatically
+        # encode the message via base64 encoding.
+        #
+        # @param messages [Array<Hash{String => String}, #to_s>] list of messages
+        #   to send; if it's a hash, then the value of key "data" will be sent
+        #   as the message. Additionally, if the hash contains a value for key
+        #   "attributes", then they will be sent as well as attributes on the
+        #   message.
+        # @return [Array<String>] list of message ids
+        def publish(messages)
+          requires :name
+
+          # Ensure our messages are base64 encoded
+          encoded_messages = []
+
+          messages.each do |message|
+            encoded_message = {}
+            if message.is_a?(Hash)
+              encoded_message["attributes"] = message["attributes"]
+              if message.key?("data")
+                encoded_message["data"] = Base64.strict_encode64(message["data"])
+              end
+            else
+              encoded_message["data"] = Base64.strict_encode64(message.to_s)
+            end
+
+            encoded_messages << encoded_message
+          end
+
+          service.publish_topic(name, encoded_messages).body["messageIds"]
+        end
+
+        # Save the instance (does the same thing as #create)
+        # @return [Fog::Google::Pubsub::Topic] this instance
+        def save
+          create
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/models/pubsub/topics.rb
+++ b/lib/fog/google/models/pubsub/topics.rb
@@ -1,0 +1,31 @@
+require "fog/core/collection"
+require "fog/google/models/pubsub/topic"
+
+module Fog
+  module Google
+    class Pubsub
+      class Topics < Fog::Collection
+        model Fog::Google::Pubsub::Topic
+
+        # Lists all topics that exist on the project.
+        #
+        # @return [Array<Fog::Google::Pubsub::Topic>] list of topics
+        def all
+          data = service.list_topics.body["topics"] || []
+          load(data)
+        end
+
+        # Retrieves a topic by name
+        #
+        # @param topic_name [String] name of topic to retrieve
+        # @return [Fog::Google::Pubsub::Topic] topic found, or nil if not found
+        def get(topic_name)
+          topic = service.get_topic(topic_name).body
+          new(topic)
+        rescue Fog::Errors::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/pubsub.rb
+++ b/lib/fog/google/pubsub.rb
@@ -1,0 +1,59 @@
+module Fog
+  module Google
+    class Pubsub < Fog::Service
+      autoload :Mock, File.expand_path("../pubsub/mock", __FILE__)
+      autoload :Real, File.expand_path("../pubsub/real", __FILE__)
+
+      requires :google_project
+      recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
+                 :app_name, :app_version, :google_json_key_location, :google_json_key_string
+
+      GOOGLE_PUBSUB_API_VERSION    = "v1".freeze
+      GOOGLE_PUBSUB_BASE_URL       = "https://www.googleapis.com/pubsub".freeze
+      GOOGLE_PUBSUB_API_SCOPE_URLS = %w(https://www.googleapis.com/auth/pubsub).freeze
+
+      ##
+      # MODELS
+      model_path "fog/google/models/pubsub"
+
+      # Topic
+      model :topic
+      collection :topics
+
+      # Subscription
+      model :subscription
+      collection :subscriptions
+
+      # ReceivedMessage
+      model :received_message
+
+      ##
+      # REQUESTS
+      request_path "fog/google/requests/pubsub"
+
+      # Topic
+      request :list_topics
+      request :get_topic
+      request :create_topic
+      request :delete_topic
+      request :publish_topic
+
+      # Subscription
+      request :list_subscriptions
+      request :get_subscription
+      request :create_subscription
+      request :delete_subscription
+      request :pull_subscription
+      request :acknowledge_subscription
+
+      # Helper class for getting a subscription name
+      #
+      # @param subscription [Subscription, #to_s] subscription instance or name
+      #   of subscription
+      # @return [String] name of subscription
+      def self.subscription_name(subscription)
+        subscription.is_a?(Subscription) ? subscription.name : subscription.to_s
+      end
+    end
+  end
+end

--- a/lib/fog/google/pubsub/mock.rb
+++ b/lib/fog/google/pubsub/mock.rb
@@ -1,0 +1,34 @@
+module Fog
+  module Google
+    class Pubsub
+      class Mock
+        include Fog::Google::Shared
+
+        def initialize(options)
+          shared_initialize(options[:google_project], GOOGLE_PUBSUB_API_VERSION, GOOGLE_PUBSUB_BASE_URL)
+        end
+
+        def self.data
+          @data ||= Hash.new do |hash, key|
+            hash[key] = {
+              :topics => {},
+              :subscriptions => {}
+            }
+          end
+        end
+
+        def self.reset
+          @data = nil
+        end
+
+        def data
+          self.class.data[project]
+        end
+
+        def reset_data
+          self.class.data.delete(project)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/pubsub/real.rb
+++ b/lib/fog/google/pubsub/real.rb
@@ -1,0 +1,20 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        include Fog::Google::Shared
+
+        attr_accessor :client
+        attr_reader :pubsub
+
+        def initialize(options)
+          shared_initialize(options[:google_project], GOOGLE_PUBSUB_API_VERSION, GOOGLE_PUBSUB_BASE_URL)
+          options[:google_api_scope_url] = GOOGLE_PUBSUB_API_SCOPE_URLS.join(" ")
+
+          @client = initialize_google_client(options)
+          @pubsub = @client.discovered_api("pubsub", api_version)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/acknowledge_subscription.rb
+++ b/lib/fog/google/requests/pubsub/acknowledge_subscription.rb
@@ -1,0 +1,46 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Acknowledges a message received from a subscription.
+        #
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/acknowledge
+        def acknowledge_subscription(subscription, ack_ids)
+          api_method = @pubsub.projects.subscriptions.acknowledge
+
+          parameters = {
+            "subscription" => subscription.to_s
+          }
+
+          body = {
+            "ackIds" => ack_ids
+          }
+
+          request(api_method, parameters, body)
+        end
+      end
+
+      class Mock
+        def acknowledge_subscription(subscription, ack_ids)
+          unless data[:subscriptions].key?(subscription)
+            subscription_resource = subscription.to_s.split("/")[-1]
+            body = {
+              "error" => {
+                "code"    => 404,
+                "message" => "Resource not found (resource=#{subscription_resource}).",
+                "status"  => "NOT_FOUND"
+              }
+            }
+            status = 404
+            return build_excon_response(body, status)
+          end
+
+          sub = data[:subscriptions][subscription]
+          sub[:messages].delete_if { |msg| ack_ids.member?(msg["messageId"]) }
+
+          build_excon_response(nil, 200)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/create_subscription.rb
+++ b/lib/fog/google/requests/pubsub/create_subscription.rb
@@ -1,0 +1,57 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Create a subscription resource on a topic.
+        #
+        # @param subscription_name [#to_s] name of the subscription to create.
+        #   Note that it must follow the restrictions of subscription names;
+        #   specifically it must be named within a project (e.g.
+        #   "projects/my-project/subscriptions/my-subscripton")
+        # @param topic [Topic, #to_s] topic instance or name of topic to create
+        #   subscription on
+        # @param push_config [Hash] configuration for a push config (if empty
+        #   hash, then no push_config is created)
+        # @param ack_deadline_seconds [Number] how long the service waits for
+        #   an acknowledgement before redelivering the message; if nil then
+        #   service default of 10 is used
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
+        def create_subscription(subscription_name, topic, push_config = {}, ack_deadline_seconds = nil)
+          api_method = @pubsub.projects.subscriptions.create
+
+          parameters = {}
+          parameters["name"] = subscription_name.to_s unless subscription_name.nil?
+
+          body = {
+            "topic" => (topic.is_a?(Topic) ? topic.name : topic.to_s)
+          }
+
+          if !push_config.nil? && push_config.key?("push_endpoint")
+            body["pushConfig"] = push_config["push_endpoint"].clone
+            body["pushConfig"]["attributes"] = push_config["attributes"] if push_config.key?("attributes")
+          end
+
+          body["ackDeadlineSeconds"] = ack_deadline_seconds unless ack_deadline_seconds.nil?
+
+          request(api_method, parameters, body)
+        end
+      end
+
+      class Mock
+        def create_subscription(subscription_name, topic, push_config = {}, ack_deadline_seconds = nil)
+          subscription = {
+            "name"               => subscription_name,
+            "topic"              => topic,
+            "pushConfig"         => push_config,
+            "ackDeadlineSeconds" => ack_deadline_seconds
+          }
+
+          # We also track pending messages
+          data[:subscriptions][subscription_name] = subscription.merge(:messages => [])
+
+          build_excon_response(subscription, 200)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/create_topic.rb
+++ b/lib/fog/google/requests/pubsub/create_topic.rb
@@ -1,0 +1,36 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Create a topic on the remote service.
+        #
+        # @param topic_name [#to_s] name of topic to create; note that it must
+        #   obey the naming rules for a topic (e.g.
+        #   'projects/myProject/topics/my_topic')
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
+        def create_topic(topic_name)
+          api_method = @pubsub.projects.topics.create
+          parameters = {
+            "name" => topic_name.to_s
+          }
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def create_topic(topic_name)
+          data = {
+            "name" => topic_name
+          }
+          self.data[:topics][topic_name] = data
+
+          body = data.clone
+          status = 200
+
+          build_excon_response(body, status)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/delete_subscription.rb
+++ b/lib/fog/google/requests/pubsub/delete_subscription.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Delete a subscription on the remote service.
+        #
+        # @param subscription_name [#to_s] name of subscription to delete
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
+        def delete_subscription(subscription_name)
+          api_method = @pubsub.projects.subscriptions.delete
+          parameters = {
+            "subscription" => subscription_name.to_s
+          }
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def delete_subscription(subscription_name)
+          data[:subscriptions].delete(subscription_name)
+
+          build_excon_response(nil, 200)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/delete_topic.rb
+++ b/lib/fog/google/requests/pubsub/delete_topic.rb
@@ -1,0 +1,29 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Delete a topic on the remote service.
+        #
+        # @param topic_name [#to_s] name of topic to delete
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
+        def delete_topic(topic_name)
+          api_method = @pubsub.projects.topics.delete
+          parameters = {
+            "topic" => topic_name.to_s
+          }
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def delete_topic(topic_name)
+          data[:topics].delete(topic_name)
+
+          status = 200
+          build_excon_response(nil, status)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/get_subscription.rb
+++ b/lib/fog/google/requests/pubsub/get_subscription.rb
@@ -1,0 +1,44 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Retrieves a subscription by name from the remote service.
+        #
+        # @param subscription_name [#to_s] name of subscription to retrieve
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
+        def get_subscription(subscription_name)
+          api_method = @pubsub.projects.subscriptions.get
+          parameters = {
+            "subscription" => subscription_name.to_s
+          }
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def get_subscription(subscription_name)
+          sub = data[:subscriptions][subscription_name]
+          if sub.nil?
+            subscription_resource = subscription_name.split("/")[-1]
+            body = {
+              "error" => {
+                "code"    => 404,
+                "message" => "Resource not found (resource=#{subscription_resource}).",
+                "status"  => "NOT_FOUND"
+              }
+            }
+            return build_excon_response(body, 404)
+          end
+
+          body = sub.select do |k, _|
+            %w(name topic pushConfig ackDeadlineSeconds).include?(k)
+          end
+          status = 200
+
+          build_excon_response(body, status)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/get_topic.rb
+++ b/lib/fog/google/requests/pubsub/get_topic.rb
@@ -1,0 +1,41 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Retrieves a resource describing a topic.
+        #
+        # @param topic_name [#to_s] name of topic to retrieve
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
+        def get_topic(topic_name)
+          api_method = @pubsub.projects.topics.get
+          parameters = {
+            "topic" => topic_name.to_s
+          }
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def get_topic(topic_name)
+          if !data[:topics].key?(topic_name)
+            topic_resource = topic_name.split("/")[-1]
+            body = {
+              "error" => {
+                "code"    => 404,
+                "message" => "Resource not found (resource=#{topic_resource}).",
+                "status"  => "NOT_FOUND"
+              }
+            }
+            status = 404
+          else
+            body = data[:topics][topic_name].clone
+            status = 200
+          end
+
+          build_excon_response(body, status)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/list_subscriptions.rb
+++ b/lib/fog/google/requests/pubsub/list_subscriptions.rb
@@ -1,0 +1,39 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Gets a list of all subscriptions for a given project.
+        #
+        # @param_name project [#to_s] Project path to list subscriptions under;
+        #   must be a project url prefix (e.g. 'projects/my-project'). If nil,
+        #   the project configured on the client is used.
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
+        def list_subscriptions(project = nil)
+          api_method = @pubsub.projects.subscriptions.list
+          parameters = {
+            "project" => (project.nil? ? "projects/#{@project}" : project.to_s)
+          }
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def list_subscriptions(_project = nil)
+          subs = data[:subscriptions].values.map do |sub|
+            # Filter out any keys that aren't part of the response object
+            sub.select do |k, _|
+              %w(name topic pushConfig ackDeadlineSeconds).include?(k)
+            end
+          end
+
+          body = {
+            "subscriptions" => subs
+          }
+          status = 200
+          build_excon_response(body, status)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/list_topics.rb
+++ b/lib/fog/google/requests/pubsub/list_topics.rb
@@ -1,0 +1,33 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Gets a list of all topics for a given project.
+        #
+        # @param_name project [#to_s] Project path to list topics under; must
+        #   be a project url prefix (e.g. 'projects/my-project'). If nil, the
+        #   project configured on the client is used.
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
+        def list_topics(project = nil)
+          api_method = @pubsub.projects.topics.list
+          parameters = {
+            "project" => (project.nil? ? "projects/#{@project}" : project.to_s)
+          }
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def list_topics(_project = nil)
+          body = {
+            "topics" => data[:topics].values
+          }
+          status = 200
+
+          build_excon_response(body, status)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/publish_topic.rb
+++ b/lib/fog/google/requests/pubsub/publish_topic.rb
@@ -1,0 +1,61 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Publish a list of messages to a topic.
+        #
+        # @param messages [Array<Hash>] List of messages to be published to a
+        #   topic; each hash should have a value defined for 'data' or for
+        #   'attributes' (or both). Note that the value associated with 'data'
+        #   must be base64 encoded.
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
+        def publish_topic(topic, messages)
+          api_method = @pubsub.projects.topics.publish
+
+          parameters = {
+            "topic" => topic
+          }
+
+          body = {
+            "messages" => messages
+          }
+
+          request(api_method, parameters, body)
+        end
+      end
+
+      class Mock
+        def publish_topic(topic, messages)
+          if data[:topics].key?(topic)
+            published_messages = messages.map do |msg|
+              msg.merge("messageId" => Fog::Mock.random_letters(16), "publishTime" => Time.now.iso8601)
+            end
+
+            # Gather the subscriptions and publish
+            data[:subscriptions].values.each do |sub|
+              next unless sub["topic"] == topic
+              sub[:messages] += published_messages
+            end
+
+            body = {
+              "messageIds" => published_messages.map { |msg| msg["messageId"] }
+            }
+            status = 200
+          else
+            topic_resource = topic_name.split("/")[-1]
+            body = {
+              "error" => {
+                "code"    => 404,
+                "message" => "Resource not found (resource=#{topic_resource}).",
+                "status"  => "NOT_FOUND"
+              }
+            }
+            status = 404
+          end
+
+          build_excon_response(body, status)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/pubsub/pull_subscription.rb
+++ b/lib/fog/google/requests/pubsub/pull_subscription.rb
@@ -1,0 +1,77 @@
+module Fog
+  module Google
+    class Pubsub
+      class Real
+        # Pulls from a subscription. If option 'return_immediately' is
+        # false, then this method blocks until one or more messages is
+        # available or the remote server closes the connection.
+        #
+        # @param subscription [Subscription, #to_s] subscription instance or
+        #   name of subscription to pull from
+        # @param options [Hash] options to modify the pull request
+        # @option options [Boolean] :return_immediately if true, method returns
+        #   after API call; otherwise the connection is held open until
+        #   messages are available or the remote server closes the connection
+        #   (defaults to true)
+        # @option options [Number] :max_messages maximum number of messages to
+        #   retrieve (defaults to 10)
+        # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/pull
+        def pull_subscription(subscription, options = { :return_immediately => true, :max_messages => 10 })
+          api_method = @pubsub.projects.subscriptions.pull
+
+          parameters = {
+            "subscription" => Fog::Google::Pubsub.subscription_name(subscription)
+          }
+
+          body = {
+            "returnImmediately" => options[:return_immediately],
+            "maxMessages" => options[:max_messages]
+          }
+
+          request(api_method, parameters, body)
+        end
+      end
+
+      class Mock
+        def pull_subscription(subscription, options = { :return_immediately => true, :max_messages => 10 })
+          # We're going to ignore return_immediately; feel free to add support
+          # if you need it for testing
+          subscription_name = Fog::Google::Pubsub.subscription_name(subscription)
+          sub = data[:subscriptions][subscription_name]
+
+          if sub.nil?
+            subscription_resource = subscription_name.split("/")[-1]
+            body = {
+              "error" => {
+                "code"    => 404,
+                "message" => "Resource not found (resource=#{subscription_resource}).",
+                "status"  => "NOT_FOUND"
+              }
+            }
+            return build_excon_response(body, 404)
+          end
+
+          # This implementation is a bit weak; instead of "hiding" messages for
+          # some period of time after they are pulled, instead we always return
+          # them until acknowledged. This might cause issues with clients that
+          # refuse to acknowledge.
+          #
+          # Also, note that here we use the message id as the ack id - again,
+          # this might cause problems with some strange-behaving clients.
+          msgs = sub[:messages].take(options[:max_messages]).map do |msg|
+            {
+              "ackId"   => msg["messageId"],
+              "message" => msg
+            }
+          end
+
+          body = {
+            "receivedMessages" => msgs
+          }
+          status = 200
+          build_excon_response(body, status)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/version.rb
+++ b/lib/fog/google/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Google
-    VERSION = "0.2.0"
+    VERSION = "0.3.0".freeze
   end
 end

--- a/tests/models/pubsub/received_message_tests.rb
+++ b/tests/models/pubsub/received_message_tests.rb
@@ -1,0 +1,18 @@
+Shindo.tests("Fog::Google[:pubsub] | received_message model", ["google"]) do
+  @connection = Fog::Google[:pubsub]
+  @topic = @connection.topics.create(:name => "projects/#{@connection.project}/topics/#{Fog::Mock.random_letters(16)}")
+  @subscription = @connection.subscriptions.create(
+    :name  => "projects/#{@connection.project}/subscriptions/#{Fog::Mock.random_letters(16)}",
+    :topic => @topic.name
+  )
+
+  tests("success") do
+    tests('#acknowledge').returns(nil) do
+      @topic.publish(["foo"])
+      @subscription.pull[0].acknowledge
+    end
+  end
+  # teardown
+  @topic.destroy
+  @subscription.destroy
+end

--- a/tests/models/pubsub/subscription_tests.rb
+++ b/tests/models/pubsub/subscription_tests.rb
@@ -1,0 +1,26 @@
+Shindo.tests("Fog::Google[:pubsub] | subscription model", ["google"]) do
+  @connection = Fog::Google[:pubsub]
+  @topic = @connection.topics.create(:name => "projects/#{@connection.project}/topics/#{Fog::Mock.random_letters(16)}")
+  @subscriptions = @connection.subscriptions
+
+  tests("success") do
+    tests('#create').succeeds do
+      @subscription = @subscriptions.create(
+        :name  => "projects/#{@connection.project}/subscriptions/#{Fog::Mock.random_letters(16)}",
+        :topic => @topic.name
+      )
+    end
+
+    tests('#pull').returns("foo") do
+      @topic.publish(["foo"])
+      @message = @subscription.pull[0]
+      @message.message["data"]
+    end
+
+    tests('#destroy').succeeds do
+      @subscription.destroy
+    end
+  end
+
+  @topic.destroy
+end

--- a/tests/models/pubsub/subscriptions_tests.rb
+++ b/tests/models/pubsub/subscriptions_tests.rb
@@ -1,0 +1,33 @@
+Shindo.tests("Fog::Google[:pubsub] | subscriptions model", ["google"]) do
+  @connection = Fog::Google[:pubsub]
+  @topic = @connection.topics.create(:name => "projects/#{@connection.project}/topics/#{Fog::Mock.random_letters(16)}")
+  @subscriptions = @connection.subscriptions
+  @subscription = @subscriptions.create(
+    :name => "projects/#{@connection.project}/subscriptions/#{Fog::Mock.random_letters(16)}",
+    :topic => @topic.name
+  )
+
+  tests("success") do
+    tests('#all').succeeds do
+      @subscriptions.all
+    end
+
+    tests('#get').succeeds do
+      @subscriptions.get(@subscription.name)
+    end
+  end
+
+  @subscription.destroy
+
+  tests("failure") do
+    tests('#all').returns([]) do
+      @subscriptions.all
+    end
+
+    tests('#get').returns(nil) do
+      @subscriptions.get(Fog::Mock.random_letters_and_numbers(16))
+    end
+  end
+
+  @topic.destroy
+end

--- a/tests/models/pubsub/topic_tests.rb
+++ b/tests/models/pubsub/topic_tests.rb
@@ -1,0 +1,18 @@
+Shindo.tests("Fog::Google[:pubsub] | topic model", ["google"]) do
+  @connection = Fog::Google[:pubsub]
+  @topics = @connection.topics
+
+  tests("success") do
+    tests('#create').succeeds do
+      @topic = @topics.create(:name => "projects/#{@connection.project}/topics/#{Fog::Mock.random_letters(16)}")
+    end
+
+    tests('#publish').succeeds do
+      @topic.publish(["foo"])
+    end
+
+    tests('#destroy').succeeds do
+      @topic.destroy
+    end
+  end
+end

--- a/tests/models/pubsub/topics_tests.rb
+++ b/tests/models/pubsub/topics_tests.rb
@@ -1,0 +1,27 @@
+Shindo.tests("Fog::Google[:pubsub] | topics model", ["google"]) do
+  @connection = Fog::Google[:pubsub]
+  @topics = @connection.topics
+  @topic = @topics.create(:name => "projects/#{@connection.project}/topics/#{Fog::Mock.random_letters(16)}")
+
+  tests("success") do
+    tests('#all').succeeds do
+      @topics.all
+    end
+
+    tests('#get').succeeds do
+      @topics.get(@topic.name)
+    end
+  end
+
+  @topic.destroy
+
+  tests("failure") do
+    tests('#all').returns([]) do
+      @topics.all
+    end
+
+    tests('#get').returns(nil) do
+      @topics.get(Fog::Mock.random_letters_and_numbers(16))
+    end
+  end
+end


### PR DESCRIPTION
This change adds some (not all) support for Google Pubsub (https://cloud.google.com/pubsub/overview)

The basics are there (topic creation/deletion/publishing, subscription creation/deleting/pulling, message acknowledging). I also added a very simple mock implementation as well as an example.