### PR TITLE
Fix for XML storage issues

### DIFF
--- a/examples/storage.rb
+++ b/examples/storage.rb
@@ -25,6 +25,18 @@ def test
   puts "---------------"
   connection.put_object("fog-smoke-test", "my file", "THISISATESTFILE")
 
+  puts "Get the test file..."
+  puts "---------------"
+  connection.get_object("fog-smoke-test", "my file")
+
+  puts "Head file..."
+  puts "---------------"
+  connection.head_object("fog-smoke-test", "my file")
+
+  puts "Get file ACL..."
+  puts "---------------"
+  connection.get_object_acl("fog-smoke-test", "my file")
+
   puts "Delete the test file..."
   puts "---------------"
   connection.delete_object("fog-smoke-test", "my file")

--- a/lib/fog/storage/google_xml/real.rb
+++ b/lib/fog/storage/google_xml/real.rb
@@ -63,7 +63,7 @@ DATA
           end
           canonical_resource << params[:path].to_s
           canonical_resource << "?"
-          params.fetch(:query, {}).keys.each do |key|
+          (params[:query] || {}).keys.each do |key|
             if %w(acl cors location logging requestPayment torrent versions versioning).include?(key)
               canonical_resource << "#{key}&"
             end

--- a/lib/fog/storage/google_xml/requests/get_object.rb
+++ b/lib/fog/storage/google_xml/requests/get_object.rb
@@ -46,7 +46,7 @@ module Fog
                                 :host           => "#{bucket_name}.#{@host}",
                                 :idempotent     => true,
                                 :method         => "GET",
-                                :path           => CGI.escape(object_name)))
+                                :path           => Fog::Google.escape(object_name)))
         end
       end
 

--- a/lib/fog/storage/google_xml/requests/get_object_acl.rb
+++ b/lib/fog/storage/google_xml/requests/get_object_acl.rb
@@ -39,7 +39,7 @@ module Fog
                   :idempotent => true,
                   :method     => "GET",
                   :parser     => Fog::Parsers::Storage::Google::AccessControlList.new,
-                  :path       => CGI.escape(object_name),
+                  :path       => Fog::Google.escape(object_name),
                   :query      => query)
         end
       end

--- a/lib/fog/storage/google_xml/requests/get_object_torrent.rb
+++ b/lib/fog/storage/google_xml/requests/get_object_torrent.rb
@@ -30,7 +30,7 @@ module Fog
                   :host       => "#{bucket_name}.#{@host}",
                   :idempotent => true,
                   :method     => "GET",
-                  :path       => CGI.escape(object_name),
+                  :path       => Fog::Google.escape(object_name),
                   :query      => { "torrent" => nil })
         end
       end

--- a/lib/fog/storage/google_xml/requests/head_object.rb
+++ b/lib/fog/storage/google_xml/requests/head_object.rb
@@ -37,7 +37,7 @@ module Fog
                   :headers  => headers,
                   :host     => "#{bucket_name}.#{@host}",
                   :method   => "HEAD",
-                  :path     => CGI.escape(object_name),
+                  :path     => Fog::Google.escape(object_name),
                   :query    => query)
         end
       end

--- a/lib/fog/storage/google_xml/requests/put_object_acl.rb
+++ b/lib/fog/storage/google_xml/requests/put_object_acl.rb
@@ -41,7 +41,7 @@ DATA
                   :host     => "#{bucket_name}.#{@host}",
                   :method   => "PUT",
                   :query    => { "acl" => nil },
-                  :path     => CGI.escape(object_name))
+                  :path     => Fog::Google.escape(object_name))
         end
       end
     end


### PR DESCRIPTION
- Fixed more path escape issues on Storage XML, didn't update everything in https://github.com/fog/fog-google/pull/83
- Fixed regression in query enumeration in `signature` method.
- Added additional line to examples using the method that failed.
Fixing #124 

/CC @plribeiro3000 or @icco PTAL