### PR TITLE
Remove the default value of "MIGRATE" for "onHostMaintenance"

### DIFF
--- a/lib/fog/compute/google/requests/insert_server.rb
+++ b/lib/fog/compute/google/requests/insert_server.rb
@@ -161,6 +161,10 @@ module Fog
           if options.key? "preemptible"
             scheduling["preemptible"] = options.delete "preemptible"
             scheduling["preemptible"] = scheduling["preemptible"].class == TrueClass
+            # If we don't have an explicit value for "on_host_maintenance, then
+            # force the value to be 'TERMINATE' as it's the default and
+            # only-accepted value for preemptible vms
+            scheduling["onHostMaintenance"] = "TERMINATE" unless options.key? "on_host_maintenance"
           end
           if options.key? "on_host_maintenance"
             ohm = options.delete "on_host_maintenance"


### PR DESCRIPTION
This value is incompatible with the default used by the GCE api;
specifically, the value 'MIGRATE' is incompatible with pre-emptible
instances. Fog-google should instead respect the default value GCE
chooses rather than imposing its own.

Fixes #136