### PR TITLE
Allow additional options to be applied to body

### DIFF
--- a/lib/fog/storage/google_json/requests/put_bucket.rb
+++ b/lib/fog/storage/google_json/requests/put_bucket.rb
@@ -10,11 +10,12 @@ module Fog
         # * options<~Hash> - config arguments for bucket.  Defaults to {}.
         #   * 'LocationConstraint'<~Symbol> - sets the location for the bucket
         #   * 'x-amz-acl'<~String> - Permissions, must be in ['private', 'public-read', 'public-read-write', 'authenticated-read']
+        # * body_options<~Hash> - body arguments for bucket creation
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * status<~Integer> - 200
-        def put_bucket(bucket_name, options = {})
+        def put_bucket(bucket_name, options = {}, body_options = {})
           location = options["LocationConstraint"] if options["LocationConstraint"]
 
           api_method = @storage_json.buckets.insert
@@ -22,18 +23,19 @@ module Fog
             "project" => @project,
             "projection" => "full"
           }
+          parameters.merge! options
           body_object = {
             "name" => bucket_name,
             "location" => location
           }
-          parameters.merge! options
+          body_object.merge! body_options
 
           request(api_method, parameters, body_object = body_object)
         end
       end
 
       class Mock
-        def put_bucket(bucket_name, options = {})
+        def put_bucket(bucket_name, options = {}, _body_options = {})
           acl = options["x-goog-acl"] || "private"
           if !%w(private publicRead publicReadWrite authenticatedRead).include?(acl)
             raise Excon::Errors::BadRequest.new("invalid x-goog-acl")


### PR DESCRIPTION
Fixes #142.

/cc @Temikus 

Note that I'm not entirely sure that this is the best way to solve this (and would welcome any discussion). Adding an additional optional parameter allows us to not break existing implementations, but it feels pretty free-form. I'm not sure it's beneficial to perform some sort of whitelist or something though as it will only restrict flexibility of the client in the future.

Thoughts?