### PR TITLE
Adding image family support

### DIFF
--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -64,6 +64,7 @@ module Fog
       request :get_global_operation
       request :get_http_health_check
       request :get_image
+      request :get_image_from_family
       request :get_instance_group
       request :get_machine_type
       request :get_network

--- a/lib/fog/compute/google/models/images.rb
+++ b/lib/fog/compute/google/models/images.rb
@@ -22,7 +22,6 @@ module Fog
 
         def all
           data = []
-          all_projects = [service.project] + global_projects
 
           all_projects.each do |project|
             begin
@@ -50,10 +49,8 @@ module Fog
         end
 
         def get(identity)
-          # Search own project before global projects
-          all_projects = [service.project] + global_projects
-
           data = nil
+
           all_projects.each do |project|
             begin
               data = service.get_image(identity, project).body
@@ -69,10 +66,8 @@ module Fog
         end
 
         def get_from_family(family)
-          # Search own project before global projects
-          all_projects = [service.project] + global_projects
-
           data = nil
+          
           all_projects.each do |project|
             begin
               data = service.get_image_from_family(family, project).body
@@ -89,8 +84,9 @@ module Fog
 
         private
 
-        def global_projects
-          GLOBAL_PROJECTS + service.extra_global_projects
+        def all_projects
+          # Search own project before global projects
+          [service.project] + GLOBAL_PROJECTS + service.extra_global_projects
         end
       end
     end

--- a/lib/fog/compute/google/models/images.rb
+++ b/lib/fog/compute/google/models/images.rb
@@ -68,6 +68,25 @@ module Fog
           new(data)
         end
 
+        def get_from_family(family)
+          # Search own project before global projects
+          all_projects = [service.project] + global_projects
+
+          data = nil
+          all_projects.each do |project|
+            begin
+              data = service.get_image_from_family(family, project).body
+              data[:project] = project
+            rescue Fog::Errors::NotFound
+              next
+            else
+              break
+            end
+          end
+          return nil if data.nil?
+          new(data)
+        end
+
         private
 
         def global_projects

--- a/lib/fog/compute/google/requests/get_image_from_family.rb
+++ b/lib/fog/compute/google/requests/get_image_from_family.rb
@@ -1,0 +1,35 @@
+module Fog
+  module Compute
+    class Google
+      # Returns the latest non-deprecated image that is part of an image family.
+      #
+      # ==== Parameters
+      # * family<~String> - Name of the image resource to return.
+      #
+      # ==== Returns
+      # * response<~Excon::Response>:
+      #   * body<~Hash> - corresponding compute#image resource
+      #
+      # ==== See also:
+      # https://cloud.google.com/compute/docs/reference/latest/images/getFromFamily
+      class Mock
+        def get_image_from_family(_family, _project = @project)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def get_image_from_family(family, project = nil)
+          api_method = @compute.images.get_from_family
+          project = @project if project.nil?
+          parameters = {
+            "family" => family,
+            "project" => project
+          }
+
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding image family support. Fixes #131 
https://cloud.google.com/compute/docs/reference/latest/images/getFromFamily

This should allow dependent projects and utilities to avoid updating image references all the time where it's not needed.

/CC @icco @plribeiro3000 

Example:
```
[3] pry(main)> gce.images.get_from_family("centos-7")
=>   <Fog::Compute::Google::Image
    name="centos-7-v20160718",
    id="1351690450177672234",
    kind="compute#image",
    archive_size_bytes="2826321723",
    creation_timestamp="2016-07-18T17:56:37.633-07:00",
    deprecated=nil,
    description="CentOS, CentOS, 7, x86_64 built on 2016-07-18",
    disk_size_gb="10",
    self_link="https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20160718",
    source_type="RAW",
    status="READY",
    project="centos-cloud",
    raw_disk={"source"=>"", "containerType"=>"TAR"}
  >
[4] pry(main)> gce.images.get_from_family("rhel-7")
=>   <Fog::Compute::Google::Image
    name="rhel-7-v20160718",
    id="6341790016827606124",
    kind="compute#image",
    archive_size_bytes="2895673247",
    creation_timestamp="2016-07-18T17:55:31.768-07:00",
    deprecated=nil,
    description="Red Hat, Red Hat Enterprise Linux, 7, x86_64 built on 2016-07-18",
    disk_size_gb="10",
    self_link="https://www.googleapis.com/compute/v1/projects/rhel-cloud/global/images/rhel-7-v20160718",
    source_type="RAW",
    status="READY",
    project="rhel-cloud",
    raw_disk={"source"=>"", "containerType"=>"TAR"}
  >
[5] pry(main)> gce.images.get_from_family("coreos-alpha")
=>   <Fog::Compute::Google::Image
    name="coreos-alpha-1122-0-0-v20160727",
    id="2311885527989963407",
    kind="compute#image",
    archive_size_bytes="317622995",
    creation_timestamp="2016-07-27T10:50:24.441-07:00",
    deprecated=nil,
    description="CoreOS, CoreOS alpha, 1122.0.0, amd64-usr published on 2016-07-27",
    disk_size_gb="9",
    self_link="https://www.googleapis.com/compute/v1/projects/coreos-cloud/global/images/coreos-alpha-1122-0-0-v20160727",
    source_type="RAW",
    status="READY",
    project="coreos-cloud",
    raw_disk={"source"=>"", "containerType"=>"TAR"}
  >
```