### PR TITLE
Make servers.get to search for identity in all parts of it's name

### DIFF
--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -21,7 +21,7 @@ module Fog
           if zone
             response = service.get_server(identity, zone).body
           else
-            servers = service.list_aggregated_servers(:filter => "name eq .*#{identity}").body["items"]
+            servers = service.list_aggregated_servers(:filter => "name eq .*#{identity}.*").body["items"]
             server = servers.each_value.select { |zone| zone.key?("instances") }
 
             # It can only be 1 server with the same name across all regions


### PR DESCRIPTION
In a given environment of 2 instances named:
- 1test
- test1

If I execute servers.get("test"), I will not receive the "test1" object, but I will receive the "1test".
