### PR TITLE
[WIP] Adding Proxy support

### DIFF
--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -29,6 +29,7 @@ module Fog
       # @option options [String] :app_name The app name to set in the user agent
       # @option options [String] :app_version The app version to set in the user agent
       # @option options [Google::APIClient] :google_client Existing Google API Client
+      # @option options [String] :proxy The proxy to send requests
       # @return [Google::APIClient] Google API Client
       # @raises [ArgumentError] If there is any missing argument
       def initialize_google_client(options)
@@ -62,7 +63,8 @@ module Fog
           signing_key,
           options[:google_api_scope_url],
           options[:app_name],
-          options[:app_version]
+          options[:app_version],
+          options[:proxy]
         )
       end
 
@@ -109,7 +111,7 @@ module Fog
       # @param [String] app_name The app name to set in the user agent
       # @param [String] app_version The app version to set in the user agent
       # @return [Google::APIClient] Google API Client
-      def new_pk12_google_client(google_client_email, signing_key, google_api_scope_url, app_name = nil, app_version = nil)
+      def new_pk12_google_client(google_client_email, signing_key, google_api_scope_url, app_name = nil, app_version = nil, proxy = nil)
         application_name = app_name.nil? ? "fog" : "#{app_name}/#{app_version || '0.0.0'} fog"
         api_client_options = {
           :application_name => application_name,
@@ -124,7 +126,8 @@ module Fog
           :issuer => google_client_email,
           :scope => google_api_scope_url,
           :signing_key => signing_key,
-          :token_credential_uri => "https://accounts.google.com/o/oauth2/token"
+          :token_credential_uri => "https://accounts.google.com/o/oauth2/token",
+          :proxy => proxy
         )
         client.authorization.fetch_access_token!
 

--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -29,7 +29,7 @@ module Fog
       # @option options [String] :app_name The app name to set in the user agent
       # @option options [String] :app_version The app version to set in the user agent
       # @option options [Google::APIClient] :google_client Existing Google API Client
-      # @option options [String] :proxy The proxy to send requests
+      # @option options [Hash] :google_client_options A hash to send adition options to Google API Client
       # @return [Google::APIClient] Google API Client
       # @raises [ArgumentError] If there is any missing argument
       def initialize_google_client(options)
@@ -64,7 +64,7 @@ module Fog
           options[:google_api_scope_url],
           options[:app_name],
           options[:app_version],
-          options[:proxy]
+          options[:google_client_options]
         )
       end
 
@@ -111,7 +111,7 @@ module Fog
       # @param [String] app_name The app name to set in the user agent
       # @param [String] app_version The app version to set in the user agent
       # @return [Google::APIClient] Google API Client
-      def new_pk12_google_client(google_client_email, signing_key, google_api_scope_url, app_name = nil, app_version = nil, proxy = nil)
+      def new_pk12_google_client(google_client_email, signing_key, google_api_scope_url, app_name = nil, app_version = nil, google_client_options = [])
         application_name = app_name.nil? ? "fog" : "#{app_name}/#{app_version || '0.0.0'} fog"
         api_client_options = {
           :application_name => application_name,
@@ -127,7 +127,7 @@ module Fog
           :scope => google_api_scope_url,
           :signing_key => signing_key,
           :token_credential_uri => "https://accounts.google.com/o/oauth2/token",
-          :proxy => proxy
+          :google_client_options => google_client_options
         )
         client.authorization.fetch_access_token!
 


### PR DESCRIPTION
As mentioned in issue #153 the Google Api client supports proxies.
This is an inital work in progress at getting proxy support in fog-google.

This is my first look at the fog-google gem, so I'm not that familiar.

I know this PR isn't complete, but thought I'd make an initial attempt and ask for feedback on what exactly else needs doing to get proxy support into fog-google.

Thanks :)
