### PR TITLE
Removing activesupport workaround

### DIFF
--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -27,12 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fog-xml"
 
   # TODO: Upgrade to 0.9, which is not compatible.
-  spec.add_development_dependency "google-api-client", "~> 0.8.6"
-  # ActiveSupport dependency is not used by fog; instead google-api-client
-  # 0.8.6 requires it. We lock it to 4.2.7 so as to avoid using 5.0, which is
-  # not compatible with older versions of Ruby. Once google-api-client is
-  # upgraded to 0.9 this should be removed.
-  spec.add_development_dependency "activesupport", "~> 4.2.7"
+  spec.add_development_dependency "google-api-client", "~> 0.8.7"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "shindo"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
Since 0.8.7 was released.
See https://github.com/google/google-api-ruby-client/issues/438
