### PR TITLE
allow copy to accept an options parameter

### DIFF
--- a/lib/fog/storage/google_json/models/file.rb
+++ b/lib/fog/storage/google_json/models/file.rb
@@ -52,9 +52,9 @@ module Fog
 
         attr_reader :directory
 
-        def copy(target_directory_key, target_file_key)
+        def copy(target_directory_key, target_file_key, options = {})
           requires :directory, :key
-          service.copy_object(directory.key, key, target_directory_key, target_file_key)
+          service.copy_object(directory.key, key, target_directory_key, target_file_key, options)
           target_directory = service.directories.new(:key => target_directory_key)
           target_directory.files.get(target_file_key)
         end

--- a/lib/fog/storage/google_xml/models/file.rb
+++ b/lib/fog/storage/google_xml/models/file.rb
@@ -45,9 +45,9 @@ module Fog
 
         attr_reader :directory
 
-        def copy(target_directory_key, target_file_key)
+        def copy(target_directory_key, target_file_key, options = {})
           requires :directory, :key
-          service.copy_object(directory.key, key, target_directory_key, target_file_key)
+          service.copy_object(directory.key, key, target_directory_key, target_file_key, options)
           target_directory = service.directories.new(:key => target_directory_key)
           target_directory.files.get(target_file_key)
         end


### PR DESCRIPTION
this creates parity with other providers such as AWS, allowing clients
to use S3 and Cloud Storage interchangeably

