### PR TITLE
Fix put_object_url and mime-type autodetect

### DIFF
--- a/lib/fog/storage/google_json/requests/put_object.rb
+++ b/lib/fog/storage/google_json/requests/put_object.rb
@@ -32,7 +32,7 @@ module Fog
           elsif data.is_a? String
             data = StringIO.new(data)
             mime_type = "text/plain"
-          elsif data.is_a? File
+          elsif data.is_a? ::File
             mime_type = Fog::Storage.parse_data(data)[:headers]["Content-Type"]
           end
 

--- a/lib/fog/storage/google_json/requests/put_object_url.rb
+++ b/lib/fog/storage/google_json/requests/put_object_url.rb
@@ -8,6 +8,9 @@ module Fog
         # * bucket_name<~String> - Name of bucket containing object
         # * object_name<~String> - Name of object to get expiring url for
         # * expires<~Time> - An expiry time for this url
+        # * If you want a file to be public you should to add { 'x-goog-acl' => 'public-read' } to headers
+        #   And then call for example: curl -H "x-goog-acl:public-read" "signed url"
+        #
         #
         # ==== Returns
         # * response<~Excon::Response>:
@@ -16,7 +19,7 @@ module Fog
         # ==== See Also
         # https://cloud.google.com/storage/docs/access-control#Signed-URLs
         #
-        def put_object_url(bucket_name, object_name, headers = {})
+        def put_object_url(bucket_name, object_name, expires, headers = {})
           raise ArgumentError.new("bucket_name is required") unless bucket_name
           raise ArgumentError.new("object_name is required") unless object_name
           https_url({


### PR DESCRIPTION
Couple bugfixies
put_object_url - add expires param
put_object - fix meme-type autodetect data.is_a?(File) returns false for file object