### PR TITLE
Fix bug where listing of bucket causes infinite loop

### DIFF
--- a/lib/fog/storage/google_json.rb
+++ b/lib/fog/storage/google_json.rb
@@ -40,6 +40,7 @@ module Fog
       request :get_object_url
       request :head_object
       request :list_buckets
+      request :list_objects
       request :put_bucket
       request :put_bucket_acl
       request :put_object

--- a/lib/fog/storage/google_json/models/file.rb
+++ b/lib/fog/storage/google_json/models/file.rb
@@ -2,7 +2,7 @@ module Fog
   module Storage
     class GoogleJSON
       class File < Fog::Model
-        identity :key, :aliases => "Key"
+        identity :key, :aliases => %w{Key name}
 
         attribute :acl
         attribute :predefined_acl

--- a/lib/fog/storage/google_json/models/files.rb
+++ b/lib/fog/storage/google_json/models/files.rb
@@ -16,22 +16,8 @@ module Fog
 
         def all(options = {})
           requires :directory
-          options = {
-            "delimiter"   => delimiter,
-            "pageToken"   => page_token,
-            "maxResults"  => max_results,
-            "prefix"      => prefix
-          }.merge!(options)
-          options = options.reject { |_key, value| value.nil? || value.to_s.empty? }
-          merge_attributes(options)
-          parent = directory.collection.get(
-            directory.key,
-            options
-          )
-          if parent
-            merge_attributes(parent.files.attributes)
-            load(parent.files.map(&:attributes))
-          end
+
+          load(service.list_objects(directory.key, options)[:body]["items"])
         end
 
         alias_method :each_file_this_page, :each

--- a/lib/fog/storage/google_json/requests/list_objects.rb
+++ b/lib/fog/storage/google_json/requests/list_objects.rb
@@ -1,0 +1,50 @@
+module Fog
+  module Storage
+    class GoogleJSON
+      class Real
+        # Lists objects in a bucket matching some criteria.
+        #
+        # @param bucket [String] name of bucket to list
+        # @param options [Hash] optional hash of options
+        # @option options [String] :delimiter Delimiter to collapse objects
+        #   under to emulate a directory-like mode
+        # @option options [Integer] :max_results Maximum number of results to
+        #   retrieve
+        # @option options [String] :page_token Token to select a particular page
+        #   of results
+        # @option options [String] :prefix String that an object must begin with
+        #   in order to be returned
+        # @option options ["full", "noAcl"] :projection Set of properties to
+        #   return (defaults to "noAcl")
+        # @option options [Boolean] :versions If true, lists all versions of an
+        #   object as distinct results (defaults to False)
+        def list_objects(bucket, options = {})
+          api_method = @storage_json.objects.list
+          parameters = {
+            "bucket" => bucket
+          }
+
+          # Optional parameters
+          {
+            :delimiter   => "delimiter",
+            :max_results => "maxResults",
+            :page_token  => "pageToken",
+            :prefix      => "prefix",
+            :projection  => "projection",
+            :versions    => "versions"
+          }.each do |k, v|
+            parameters[v] = options[k] unless options[k].nil?
+          end
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def list_objects(_bucket, _options = {})
+          Fog::Mock.not_implemented
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #151 

Guys, I'm not sure that the json storage implementation is working; I couldn't find an implementation of `list_objects` and had to add one, and the file/directory abstractions contain a lot of stuff that doesn't match to the json api (hence the addition of the `name` alias change below in `file.rb`).

I'm trying to make this change as minor as possible in order to fix the bug, but I think it might be beneficial to revisit the entire storage json implementation.