### PR TITLE
Fix push_config to be proper structure

### DIFF
--- a/lib/fog/google/requests/pubsub/create_subscription.rb
+++ b/lib/fog/google/requests/pubsub/create_subscription.rb
@@ -26,9 +26,8 @@ module Fog
             "topic" => (topic.is_a?(Topic) ? topic.name : topic.to_s)
           }
 
-          if !push_config.nil? && push_config.key?("push_endpoint")
-            body["pushConfig"] = push_config["push_endpoint"].clone
-            body["pushConfig"]["attributes"] = push_config["attributes"] if push_config.key?("attributes")
+          unless push_config.empty?
+            body["pushConfig"] = push_config
           end
 
           body["ackDeadlineSeconds"] = ack_deadline_seconds unless ack_deadline_seconds.nil?


### PR DESCRIPTION
Existing code assigns the push_endpoint value directly to pushConfig,
which is not matching the structure defined at
https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions#PushConfig

Instead we just directly take the supplied hash.