### PR TITLE
Fixing NotFound error class in Storage JSON

### DIFF
--- a/lib/fog/storage/google_json/models/directories.rb
+++ b/lib/fog/storage/google_json/models/directories.rb
@@ -16,7 +16,7 @@ module Fog
                                                 :prefix     => "prefix")
           data = service.get_bucket(key, options).body
           new(:key => data["name"])
-        rescue Excon::Errors::NotFound
+        rescue Fog::Errors::NotFound
           nil
         end
       end

--- a/lib/fog/storage/google_json/models/directory.rb
+++ b/lib/fog/storage/google_json/models/directory.rb
@@ -16,7 +16,7 @@ module Fog
           requires :key
           service.delete_bucket(key)
           true
-        rescue Excon::Errors::NotFound
+        rescue Fog::Errors::NotFound
           false
         end
 

--- a/lib/fog/storage/google_json/models/file.rb
+++ b/lib/fog/storage/google_json/models/file.rb
@@ -63,7 +63,7 @@ module Fog
           requires :directory, :key
           service.delete_object(directory.key, key)
           true
-        rescue Excon::Errors::NotFound
+        rescue Fog::Errors::NotFound
           false
         end
 

--- a/lib/fog/storage/google_json/models/files.rb
+++ b/lib/fog/storage/google_json/models/files.rb
@@ -47,7 +47,7 @@ module Fog
           file_data.merge!(:body => data.body,
                            :key  => key)
           new(file_data)
-        rescue Excon::Errors::NotFound
+        rescue Fog::Errors::NotFound
           nil
         end
 
@@ -61,7 +61,7 @@ module Fog
           data = service.head_object(directory.key, key, options)
           file_data = data.headers.merge(:key => key)
           new(file_data)
-        rescue Excon::Errors::NotFound
+        rescue Fog::Errors::NotFound
           nil
         end
 

--- a/lib/fog/storage/google_xml/models/file.rb
+++ b/lib/fog/storage/google_xml/models/file.rb
@@ -54,11 +54,10 @@ module Fog
 
         def destroy
           requires :directory, :key
-          begin
-            service.delete_object(directory.key, key)
-          rescue Excon::Errors::NotFound
-          end
+          service.delete_object(directory.key, key)
           true
+        rescue Excon::Errors::NotFound
+          false
         end
 
         remove_method :metadata


### PR DESCRIPTION
In lib/fog/google/shared.rb:181 a Fog::Error::NotFound is raised
when a request returns 404 but in our models we were rescuing
Excon::Error::NotFound.

Fixing #161 

@plribeiro3000 @icco PTAL

Seems to work correctly now:
```
λ bundle exec rake console
[1] pry(main)> connection = Fog::Storage::GoogleJSON.new; :ok
=> :ok
[2] pry(main)> dir = connection.directories.get('fog-testing')
=>   <Fog::Storage::GoogleJSON::Directory
    key="fog-testing"
  >
[3] pry(main)> dir.files.get("idonotexist.jpeg")
=> nil
[4] pry(main)> dir.files.head("idonotexist.jpeg")
=> nil
[9] pry(main)> dir.files.get("00818_sanfranciscoseascape_2560x1600.jpeg");
[10] pry(main)> file = dir.files.get("00818_sanfranciscoseascape_2560x1600.jpeg");
...
deleted the file
...
[11] pry(main)> file.destroy
=> false
[12] pry(main)> connection.directories.get('fog-testing-nonexistent')
=> nil
```