### PR TITLE
Improve disk autodelete method

### DIFF
--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -162,12 +162,12 @@ module Fog
           data.body["contents"]
         end
 
-        def set_disk_auto_delete(auto_delete, device_name=nil)
+        def set_disk_auto_delete(auto_delete, device_name = nil)
           requires :identity, :zone
 
           unless device_name
-            if self.disks.count <= 1
-              device_name = self.disks[0]['deviceName']
+            if disks.count <= 1
+              device_name = disks[0]["deviceName"]
             else
               raise ArgumentError.new("Device name required if multiple disks are attached")
             end

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -162,8 +162,16 @@ module Fog
           data.body["contents"]
         end
 
-        def set_disk_auto_delete(auto_delete, device_name)
+        def set_disk_auto_delete(auto_delete, device_name=nil)
           requires :identity, :zone
+
+          unless device_name
+            if self.disks.count <= 1
+              device_name = self.disks[0]['deviceName']
+            else
+              raise ArgumentError.new("Device name required if multiple disks are attached")
+            end
+          end
 
           data = service.set_server_disk_auto_delete(identity, zone_name, auto_delete, device_name)
           Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], data.body["zone"])


### PR DESCRIPTION
Fixes #166

Now disk autodelete can be called with one argument if there's only
one disk attached:
```
[3] pry(main)> server = gce.servers.get("server-id-cdc128b11b50");
[4] pry(main)> server.set_disk_auto_delete(true)
=>   <Fog::Compute::Google::Operation
...
    status="DONE",
...
```
I think this is a good compromise, since the canonical API call target is "deviceName", but I don't want to introduce iterative logic that enumerates all disks and scans their source URL's.

@icco PTAL