### PR TITLE
Add tests for addresses resource

### DIFF
--- a/test/helpers/client_helper.rb
+++ b/test/helpers/client_helper.rb
@@ -1,0 +1,35 @@
+##
+# Helper mixin for tests (especially compute-based ones). Provide access to the
+# client in use via the #client method to use.
+
+module ClientHelper
+  # Check to see if an operation is finished.
+  #
+  # @param op [Excon::Response] the operation object returned from an api call
+  # @return [Boolean] true if the operation is no longer executing, false
+  #   otherwise
+  def operation_finished?(op)
+    # TODO: support both zone and region operations
+    region = op[:body]["region"]
+    name = op[:body]["name"]
+
+    result = client.get_region_operation(region, name)
+    !%w(PENDING RUNNING).include?(result[:body]["status"])
+  end
+
+  # Pause execution until an operation returned from a passed block is finished.
+  #
+  # @example Pause until server is provisioned
+  #   @result = wait_until_complete { client.insert_server(name, zone, opts) }
+  # @yieldreturn [Excon::Response] the resulting operation object from a block.
+  # @return [Excon::Response] the final completed operation object
+  def wait_until_complete
+    result = yield
+    return result unless result[:body]["kind"] == "compute#operation"
+
+    # TODO: support both zone and region operations
+    region = result[:body]["region"]
+    Fog.wait_for { operation_finished?(result) }
+    client.get_region_operation(region, result[:body]["name"])
+  end
+end

--- a/test/integration/compute/requests/test_compute_address_requests.rb
+++ b/test/integration/compute/requests/test_compute_address_requests.rb
@@ -2,7 +2,7 @@ require "helpers/integration_test_helper"
 require "helpers/client_helper"
 require "securerandom"
 
-class TestComputeAddresses < FogIntegrationTest
+class TestComputeAddressRequests < FogIntegrationTest
   DEFAULT_REGION = "us-central1".freeze
   ADDRESS_RESOURCE_PREFIX = "fog-test-address".freeze
 

--- a/test/integration/compute/test_addresses.rb
+++ b/test/integration/compute/test_addresses.rb
@@ -1,0 +1,93 @@
+require "helpers/integration_test_helper"
+require "securerandom"
+
+class TestComputeAddresses < FogIntegrationTest
+  DEFAULT_REGION = "us-central1".freeze
+  ADDRESS_RESOURCE_PREFIX = "fog-test-address".freeze
+
+  # Ensure we clean up any created resources
+  Minitest.after_run do
+    client = Fog::Compute::Google.new
+    addresses = client.list_addresses(DEFAULT_REGION)[:body]["items"]
+    unless addresses.nil?
+      addresses.
+        map { |a| a["name"] }.
+        select { |a| a.start_with?(ADDRESS_RESOURCE_PREFIX) }.
+        each { |a| client.delete_address(a, DEFAULT_REGION) }
+    end
+  end
+
+  def setup
+    @client = Fog::Compute::Google.new
+  end
+
+  def new_address_name
+    "#{ADDRESS_RESOURCE_PREFIX}-#{SecureRandom.uuid}"
+  end
+
+  def some_address_name
+    # created lazily to speed tests up
+    @some_address ||= new_address_name.tap do |a|
+      result = @client.insert_address(a, DEFAULT_REGION)
+      Fog.wait_for { operation_finished?(result[:body]["name"]) }
+    end
+  end
+
+  def operation_finished?(name)
+    operation = @client.get_region_operation(DEFAULT_REGION, name)
+    !%w(PENDING RUNNING).include?(operation[:body]["status"])
+  end
+
+  def wait_until_complete
+    result = yield
+    return result unless result[:body]["kind"] == "compute#operation"
+
+    operation_name = result[:body]["name"]
+    Fog.wait_for { operation_finished?(operation_name) }
+    @client.get_region_operation(DEFAULT_REGION, operation_name)
+  end
+
+  def test_insert_address
+    result = wait_until_complete { @client.insert_address(new_address_name, DEFAULT_REGION) }
+
+    assert_equal(200, result.status, "request should be successful")
+    assert_equal(nil, result[:body]["error"], "result should contain no errors")
+  end
+
+  def test_get_address
+    result = @client.get_address(some_address_name, DEFAULT_REGION)
+
+    assert_equal(200, result.status, "request should be successful")
+    assert_includes(result[:body].keys, "name", "resulting body should contain expected keys")
+  end
+
+  def test_list_address
+    # Let's create at least one address so there's something to view
+    wait_until_complete { @client.insert_address(new_address_name, DEFAULT_REGION) }
+
+    result = @client.list_addresses(DEFAULT_REGION)
+
+    assert_equal(200, result.status, "request should be successful")
+    assert_includes(result[:body].keys, "items", "resulting body should contain expected keys")
+    assert_operator(result[:body]["items"].size, :>, 0, "address count should be positive")
+  end
+
+  def test_delete_address
+    # Create something to delete
+    address_to_delete = new_address_name
+    wait_until_complete { @client.insert_address(address_to_delete, DEFAULT_REGION) }
+
+    result = wait_until_complete { @client.delete_address(address_to_delete, DEFAULT_REGION) }
+
+    assert_equal(200, result.status, "request should be successful")
+    assert_equal(nil, result[:body]["error"], "result should contain no errors")
+  end
+
+  def test_list_aggregated_addresses
+    result = @client.list_aggregated_addresses
+
+    assert_equal(200, result.status, "request should be successful")
+    assert_includes(result[:body].keys, "items", "resulting body should contain expected keys")
+    assert_includes(result[:body]["items"].keys, "global", "resulting body 'items' subset should contain global keyword")
+  end
+end

--- a/test/integration/compute/test_compute_addresses_collection.rb
+++ b/test/integration/compute/test_compute_addresses_collection.rb
@@ -1,0 +1,74 @@
+require "helpers/integration_test_helper"
+require "securerandom"
+
+class TestComputeAddressesCollection < FogIntegrationTest
+  DEFAULT_REGION = "us-central1".freeze
+  DEFAULT_ZONE = "us-central1-b".freeze
+  RESOURCE_PREFIX = "fog-test-addresscol".freeze
+
+  # Ensure we clean up any created resources
+  Minitest.after_run do
+    client = Fog::Compute::Google.new
+    client.addresses.each { |a| a.destroy if a.name.start_with?(RESOURCE_PREFIX) }
+    client.servers.each { |s| s.destroy if s.name.start_with?(RESOURCE_PREFIX) }
+  end
+
+  def test_address_workflow
+    client = Fog::Compute::Google.new
+
+    my_address_name = new_resource_name
+    # An address can be created by specifying a name and a region
+    my_address = client.addresses.create(
+      :name => my_address_name,
+      :region => DEFAULT_REGION
+    )
+    # TODO: Shouldn't this be returning an operation object that we have to explicitly wait for?
+    assert_equal(my_address_name, my_address.name, "My address should have the provided name")
+    assert_equal("RESERVED", my_address.status, "My address should not be in use")
+
+    # It should also be visible when listing addresses
+    assert_includes(client.addresses.all.map(&:name), my_address_name)
+
+    # Be aware that although the address resource is created, it might not yet
+    # have an ip address. You can poll until the address has been assigned.
+    my_address.wait_for { !my_address.address.nil? }
+    assert_match(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/,
+                 my_address.address,
+                 "My address's address should have a valid ipv4 address")
+
+    # Now that we have an address, we can create a server using the static ip
+    my_server = client.servers.create(
+      :name => new_resource_name,
+      :machine_type => "f1-micro",
+      :zone_name => DEFAULT_ZONE,
+      :disks => [
+        :boot => true,
+        :autoDelete => true,
+        :initializeParams => {
+          :sourceImage => "projects/debian-cloud/global/images/family/debian-8"
+        }
+      ],
+      :external_ip => my_address.address
+    )
+    my_server.wait_for { my_server.state != "PROVISIONING" }
+
+    # And verify that it's correctly assigned
+    assert_equal(
+      my_address.address,
+      my_server.network_interfaces[0]["accessConfigs"][0]["natIP"],
+      "My created server should have the same ip as my address"
+    )
+
+    # If we look up the address again by name, we should see that it is now
+    # in use
+    assert_equal(
+      "IN_USE",
+      client.addresses.get(my_address_name, DEFAULT_REGION).status,
+      "Address should now be in use"
+    )
+  end
+
+  def new_resource_name
+    "#{RESOURCE_PREFIX}-#{SecureRandom.uuid}"
+  end
+end


### PR DESCRIPTION
This adds some basic end-to-end tests covering requests for the 'addresses' resource in compute. It's very similar to the pubsub tests.

I was going to use this as well as the pubsub tests to try to generalize some test helpers for testing basic CRUD testing without having to add all the boilerplate, but I'm holding off on that for now as my first attempt made the tests too hard to read. I'm opening a PR for this at the moment though as it's useful in its current form.