### PR TITLE
Make server.add_ssh_key an operation

### DIFF
--- a/examples/create_instance.rb
+++ b/examples/create_instance.rb
@@ -9,13 +9,12 @@ Bundler.require(:default, :development)
 def test
   connection = Fog::Compute.new(:provider => "Google")
 
-  name = "fog-smoke-test-#{Time.now.to_i}"
-
   disk = connection.disks.create(
-    :name => name,
+    :name => "fog-smoke-test-#{Time.now.to_i}",
     :size_gb => 10,
     :zone_name => "us-central1-f",
-    :source_image => "debian-7-wheezy-v20151104")
+    :source_image => "debian-8-jessie-v20161215"
+  )
 
   disk.wait_for { disk.ready? }
 
@@ -28,7 +27,8 @@ def test
     :zone_name => "us-central1-f",
     :user => ENV["USER"],
     :tags => ["fog"],
-    :service_accounts => %w(sql-admin bigquery https://www.googleapis.com/auth/compute))
+    :service_accounts => %w(sql-admin bigquery https://www.googleapis.com/auth/compute)
+  )
 
   # Wait_for routine copied here to show errors, if necessary.
   duration = 0

--- a/examples/get_list_images.rb
+++ b/examples/get_list_images.rb
@@ -23,7 +23,7 @@ def test
 
   puts "Fetching a single image from a global project..."
   puts "------------------------------------------------"
-  img = connection.images.get("debian-7-wheezy-v20151104")
+  img = connection.images.get("debian-8-jessie-v20161215")
   raise "Could not GET the image" unless img
   puts img.inspect
 

--- a/examples/metadata.rb
+++ b/examples/metadata.rb
@@ -15,7 +15,8 @@ def test
     :name => name,
     :size_gb => 10,
     :zone_name => "us-central1-f",
-    :source_image => "debian-7-wheezy-v20131120")
+    :source_image => "debian-8-jessie-v20161215"
+  )
 
   disk.wait_for { disk.ready? }
 

--- a/examples/network.rb
+++ b/examples/network.rb
@@ -10,7 +10,8 @@ def test
     :name => name,
     :size_gb => 10,
     :zone_name => "us-central1-a",
-    :source_image => "debian-7-wheezy-v20131120")
+    :source_image => "debian-8-jessie-v20161215"
+  )
 
   disk.wait_for { disk.ready? }
 

--- a/lib/fog/compute/google/mock.rb
+++ b/lib/fog/compute/google/mock.rb
@@ -17,80 +17,69 @@ module Fog
               when "debian-cloud"
                 {
                   :images => {
-                    "debian-6-squeeze-v20130816" => {
+                    "debian-8-jessie-v20161215" => {
+                      "archiveSizeBytes" => "3436783050",
+                      "creationTimestamp" => "2016-12-15T12 =>53 =>12.508-08 =>00",
+                      "description" => "Debian, Debian GNU/Linux, 8 (jessie), amd64 built on 2016-12-15",
+                      "diskSizeGb" => "10",
+                      "family" => "debian-8",
+                      "id" => "7187216073735715927",
                       "kind" => "compute#image",
-                      "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/debian-cloud/global/images/debian-6-squeeze-v20130816",
-                      "id" => "14841592146580482051",
-                      "creationTimestamp" => "2013-09-04T13:21:53.292-07:00",
-                      "name" => "debian-6-squeeze-v20130816",
-                      "description" => "Debian GNU/Linux 6.0.7 (squeeze) built on 2013-08-16",
-                      "sourceType" => "RAW",
+                      "licenses" => [
+                        "https://www.googleapis.com/compute/#{api_version}/projects/debian-cloud/global/licenses/debian-8-jessie"
+                      ],
+                      "name" => "debian-8-jessie-v20161215",
                       "rawDisk" => {
                         "containerType" => "TAR",
                         "source" => ""
                       },
+                      "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/debian-cloud/global/images/debian-8-jessie-v20161215",
+                      "sourceType" => "RAW",
                       "status" => "READY"
-                    },
-                    "debian-7-wheezy-v20130816" => {
-                      "kind" => "compute#image",
-                      "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/debian-cloud/global/images/debian-7-wheezy-v20130816",
-                      "id" => "4213305957435180899",
-                      "creationTimestamp" => "2013-09-04T13:24:30.479-07:00",
-                      "name" => "debian-7-wheezy-v20130816",
-                      "description" => "Debian GNU/Linux 7.1 (wheezy) built on 2013-08-16",
-                      "sourceType" => "RAW",
-                      "rawDisk" => {
-                        "containerType" => "TAR",
-                        "source" => ""
-                      },
-                      "status" => "READY"
-                    },
-                    "debian-7-wheezy-v20131014" => {
-                      "kind" => "compute#image",
-                      "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/debian-cloud/global/images/debian-7-wheezy-v20131014",
-                      "id" => "4213305957435180899",
-                      "creationTimestamp" => "2013-09-04T13:24:30.479-07:00",
-                      "name" => "debian-7-wheezy-v20131014",
-                      "description" => "Debian GNU/Linux 7.1 (wheezy) built on 2013-10-14",
-                      "sourceType" => "RAW",
-                      "rawDisk" => {
-                        "containerType" => "TAR",
-                        "source" => ""
-                      },
-                      "status" => "READY"
-                    },
-                    "debian-7-wheezy-v20140408" => {
-                      "kind" => "compute#image",
-                      "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/debian-cloud/global/images/debian-7-wheezy-v20140408",
-                      "id" => "17312518942796567788",
-                      "creationTimestamp" => "2013-11-25T15:17:00.436-08:00",
-                      "name" => "debian-7-wheezy-v20131120",
-                      "description" => "Debian GNU/Linux 7.2 (wheezy) built on 2013-11-20",
-                      "sourceType" => "RAW",
-                      "rawDisk" => {
-                        "containerType" => "TAR",
-                        "source" => ""
-                      },
-                      "status" => "READY",
-                      "archiveSizeBytes" => "341857472"
                     }
                   }
                 }
               when "centos-cloud"
                 {
                   :images => {
-                    "centos-6-v20130813" => {
+                    "centos-6-v20161212" => {
+                      "archiveSizeBytes" => "3942360630",
+                      "creationTimestamp" => "2016-12-14T10 =>30 =>52.053-08 =>00",
+                      "description" => "CentOS, CentOS, 6, x86_64 built on 2016-12-12",
+                      "diskSizeGb" => "10",
+                      "family" => "centos-6",
+                      "id" => "5262726857160929587",
                       "kind" => "compute#image",
-                      "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/centos-cloud/global/images/centos-6-v20130813",
-                      "id" => "4670523370938782739",
-                      "creationTimestamp" => "2013-08-19T11:56:47.004-07:00",
-                      "name" => "centos-6-v20130813",
-                      "description" => "SCSI-enabled CentOS 6; Created Tue, 13 Aug 2013 00:00:00 +0000",
-                      "sourceType" => "RAW",
+                      "licenses" => [
+                        "https://www.googleapis.com/compute/#{api_version}/projects/centos-cloud/global/licenses/centos-6"
+                      ],
+                      "name" => "centos-6-v20161212",
                       "rawDisk" => {
                         "containerType" => "TAR",
                         "source" => ""
                       },
+                      "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/centos-cloud/global/images/centos-6-v20161212",
+                      "sourceType" => "RAW",
+                      "status" => "READY"
+                    },
+                    "centos-7-v20161212" => {
+                      "archiveSizeBytes" => "4491098988",
+                      "creationTimestamp" => "2016-12-14T10 =>29 =>44.741-08 =>00",
+                      "description" => "CentOS, CentOS, 7, x86_64 built on 2016-12-12",
+                      "diskSizeGb" => "10",
+                      "family" => "centos-7",
+                      "id" => "8650499281020268919",
+                      "kind" => "compute#image",
+                      "licenses" => [
+                        "https://www.googleapis.com/compute/#{api_version}/projects/centos-cloud/global/licenses/centos-7"
+                      ],
+                      "name" => "centos-7-v20161212",
+                      "rawDisk" => {
+                        "containerType" => "TAR",
+                        "source" => ""
+                      },
+                      "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/centos-cloud/global/images/centos-7-v20161212",
+                      "sourceType" => "RAW",
                       "status" => "READY"
                     }
                   }

--- a/lib/fog/compute/google/models/image.rb
+++ b/lib/fog/compute/google/models/image.rb
@@ -11,6 +11,8 @@ module Fog
         attribute :deprecated
         attribute :description
         attribute :disk_size_gb, :aliases => "diskSizeGb"
+        attribute :family
+        attribute :licenses
         attribute :self_link, :aliases => "selfLink"
         attribute :source_type, :aliases => "sourceType"
         attribute :status

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -221,7 +221,7 @@ module Fog
           metadata[metadata_key] += "\n" unless metadata[metadata_key].empty?
           metadata[metadata_key] += "#{username}:#{key.strip}"
 
-          metadata
+          set_metadata(metadata)
         end
 
         def map_service_accounts(scope_array)

--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -45,7 +45,7 @@ module Fog
               :name => name,
               :size_gb => 10,
               :zone_name => zone,
-              :source_image => "debian-7-wheezy-v20151104"
+              :source_image => "debian-8-jessie-v20161215"
             }
 
             # backwards compatibility to pre-v1

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -34,7 +34,7 @@ def create_test_disk(connection, zone)
                                    :name => "fog-test-disk-#{random_string}",
                                    :size_gb => "10",
                                    :zone => zone,
-                                   :source_image => "debian-7-wheezy-v20140408"
+                                   :source_image => "debian-8-jessie-v20161215"
                                  })
   disk.wait_for { ready? }
   disk

--- a/tests/requests/compute/disk_tests.rb
+++ b/tests/requests/compute/disk_tests.rb
@@ -50,7 +50,7 @@ Shindo.tests("Fog::Compute[:google] | disk requests", ["google"]) do
     disk_name = "new-disk-test"
     disk_size = "2"
     zone_name = "us-central1-a"
-    image_name = "debian-7-wheezy-v20140408"
+    image_name = "debian-8-jessie-v20161215"
 
     # These will all fail if errors happen on insert
     tests("#insert_disk").formats(@insert_disk_format) do


### PR DESCRIPTION
Follow-up to #185 

It seems that add_ssh_key never actually performed an operation but rather changed the metadata of the currently saved `server` object. Since one can ?no longer? call `server.save` on an existing instance, this method seems useless without an actual call to metadata update.

@icco @selmanj - PTAL, since I think I may be missing something.

P.S. Updated all the instance templates, since some older wheezy images do not support `ssh-key` metadata + we had some images from !2014! in tests/bootstrap.