### PR TITLE
Fixing regression in Server.insert

### DIFF
--- a/examples/create_instance.rb
+++ b/examples/create_instance.rb
@@ -25,7 +25,7 @@ def test
     :private_key_path => File.expand_path("~/.ssh/id_rsa"),
     :public_key_path => File.expand_path("~/.ssh/id_rsa.pub"),
     :zone_name => "us-central1-f",
-    :user => ENV["USER"],
+    :username => ENV["USER"],
     :tags => ["fog"],
     :service_accounts => %w(sql-admin bigquery https://www.googleapis.com/auth/compute)
   )


### PR DESCRIPTION
Fixing #189 by separating the logic into a private method.

@selmanj PTAL

P.S. Fixed our example since `:user` attribute doesn't actually exist in the core Server model:
```
attr_writer :username, :private_key, :private_key_path, :public_key, :public_key_path, :ssh_port, :ssh_options
```