### PR TITLE
Check for nil in google_client_options and use a {} if not set

### DIFF
--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -64,7 +64,7 @@ module Fog
           options[:google_api_scope_url],
           options[:app_name],
           options[:app_version],
-          options[:google_client_options]
+          options[:google_client_options] || {}
         )
       end
 


### PR DESCRIPTION
/cc @erjohnso @Temikus 