### PR TITLE
Add recognize for google client options

### DIFF
--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -5,8 +5,17 @@ module Fog
       autoload :Real, File.expand_path("../google/real", __FILE__)
 
       requires :google_project
-      recognizes :app_name, :app_version, :google_client_email, :google_key_location, :google_key_string,
-                 :google_client, :google_json_key_location, :google_json_key_string, :google_extra_global_projects
+      recognizes(
+        :app_name,
+        :app_version,
+        :google_client_email,
+        :google_key_location,
+        :google_key_string,
+        :google_client,
+        :google_json_key_location,
+        :google_json_key_string,
+        :google_extra_global_projects
+      )
 
       GOOGLE_COMPUTE_API_VERSION     = "v1"
       GOOGLE_COMPUTE_BASE_URL        = "https://www.googleapis.com/compute/"

--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -8,14 +8,14 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_client,
         :google_client_email,
+        :google_client_options,
+        :google_extra_global_projects,
         :google_key_location,
         :google_key_string,
-        :google_client,
-        :google_client_options,
         :google_json_key_location,
-        :google_json_key_string,
-        :google_extra_global_projects
+        :google_json_key_string
       )
 
       GOOGLE_COMPUTE_API_VERSION     = "v1"

--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -12,6 +12,7 @@ module Fog
         :google_key_location,
         :google_key_string,
         :google_client,
+        :google_client_options,
         :google_json_key_location,
         :google_json_key_string,
         :google_extra_global_projects

--- a/lib/fog/dns/google.rb
+++ b/lib/fog/dns/google.rb
@@ -8,11 +8,11 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_client,
         :google_client_email,
+        :google_client_options,
         :google_key_location,
         :google_key_string,
-        :google_client,
-        :google_client_options,
         :google_json_key_location,
         :google_json_key_string
       )

--- a/lib/fog/dns/google.rb
+++ b/lib/fog/dns/google.rb
@@ -5,8 +5,16 @@ module Fog
       autoload :Real, File.expand_path("../google/real", __FILE__)
 
       requires :google_project
-      recognizes :app_name, :app_version, :google_client_email, :google_key_location, :google_key_string,
-                 :google_client, :google_json_key_location, :google_json_key_string
+      recognizes(
+        :app_name,
+        :app_version,
+        :google_client_email,
+        :google_key_location,
+        :google_key_string,
+        :google_client,
+        :google_json_key_location,
+        :google_json_key_string
+      )
 
       GOOGLE_DNS_API_VERSION     = "v1"
       GOOGLE_DNS_BASE_URL        = "https://www.googleapis.com/dns/"

--- a/lib/fog/dns/google.rb
+++ b/lib/fog/dns/google.rb
@@ -12,6 +12,7 @@ module Fog
         :google_key_location,
         :google_key_string,
         :google_client,
+        :google_client_options,
         :google_json_key_location,
         :google_json_key_string
       )

--- a/lib/fog/google/monitoring.rb
+++ b/lib/fog/google/monitoring.rb
@@ -5,8 +5,16 @@ module Fog
       autoload :Real, File.expand_path("../monitoring/real", __FILE__)
 
       requires :google_project
-      recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
-                 :app_name, :app_version, :google_json_key_location, :google_json_key_string
+      recognizes(
+        :google_client_email,
+        :google_key_location,
+        :google_key_string,
+        :google_client,
+        :app_name,
+        :app_version,
+        :google_json_key_location,
+        :google_json_key_string
+      )
 
       GOOGLE_MONITORING_API_VERSION    = "v2beta2".freeze
       GOOGLE_MONITORING_BASE_URL       = "https://www.googleapis.com/cloudmonitoring/"

--- a/lib/fog/google/monitoring.rb
+++ b/lib/fog/google/monitoring.rb
@@ -10,6 +10,7 @@ module Fog
         :google_key_location,
         :google_key_string,
         :google_client,
+        :google_client_options,
         :app_name,
         :app_version,
         :google_json_key_location,

--- a/lib/fog/google/monitoring.rb
+++ b/lib/fog/google/monitoring.rb
@@ -6,13 +6,13 @@ module Fog
 
       requires :google_project
       recognizes(
-        :google_client_email,
-        :google_key_location,
-        :google_key_string,
-        :google_client,
-        :google_client_options,
         :app_name,
         :app_version,
+        :google_client,
+        :google_client_email,
+        :google_client_options,
+        :google_key_location,
+        :google_key_string,
         :google_json_key_location,
         :google_json_key_string
       )

--- a/lib/fog/google/pubsub.rb
+++ b/lib/fog/google/pubsub.rb
@@ -10,6 +10,7 @@ module Fog
         :google_key_location,
         :google_key_string,
         :google_client,
+        :google_client_options,
         :app_name,
         :app_version,
         :google_json_key_location,

--- a/lib/fog/google/pubsub.rb
+++ b/lib/fog/google/pubsub.rb
@@ -5,8 +5,16 @@ module Fog
       autoload :Real, File.expand_path("../pubsub/real", __FILE__)
 
       requires :google_project
-      recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
-                 :app_name, :app_version, :google_json_key_location, :google_json_key_string
+      recognizes(
+        :google_client_email,
+        :google_key_location,
+        :google_key_string,
+        :google_client,
+        :app_name,
+        :app_version,
+        :google_json_key_location,
+        :google_json_key_string
+      )
 
       GOOGLE_PUBSUB_API_VERSION    = "v1".freeze
       GOOGLE_PUBSUB_BASE_URL       = "https://www.googleapis.com/pubsub".freeze

--- a/lib/fog/google/sql.rb
+++ b/lib/fog/google/sql.rb
@@ -5,8 +5,16 @@ module Fog
       autoload :Real, File.expand_path("../sql/real", __FILE__)
 
       requires :google_project
-      recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
-                 :app_name, :app_version, :google_json_key_location, :google_json_key_string
+      recognizes(
+        :google_client_email,
+        :google_key_location,
+        :google_key_string,
+        :google_client,
+        :app_name,
+        :app_version,
+        :google_json_key_location,
+        :google_json_key_string
+      )
 
       GOOGLE_SQL_API_VERSION    = "v1beta3"
       GOOGLE_SQL_BASE_URL       = "https://www.googleapis.com/sql/"

--- a/lib/fog/google/sql.rb
+++ b/lib/fog/google/sql.rb
@@ -10,6 +10,7 @@ module Fog
         :google_key_location,
         :google_key_string,
         :google_client,
+        :google_client_options,
         :app_name,
         :app_version,
         :google_json_key_location,

--- a/lib/fog/google/sql.rb
+++ b/lib/fog/google/sql.rb
@@ -6,13 +6,13 @@ module Fog
 
       requires :google_project
       recognizes(
-        :google_client_email,
-        :google_key_location,
-        :google_key_string,
-        :google_client,
-        :google_client_options,
         :app_name,
         :app_version,
+        :google_client,
+        :google_client_email,
+        :google_client_options,
+        :google_key_location,
+        :google_key_string,
         :google_json_key_location,
         :google_json_key_string
       )

--- a/lib/fog/storage/google_json.rb
+++ b/lib/fog/storage/google_json.rb
@@ -6,8 +6,16 @@ module Fog
       autoload :Utils, File.expand_path("../google_json/utils", __FILE__)
 
       requires :google_project
-      recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
-                 :app_name, :app_version, :google_json_key_location, :google_json_key_string
+      recognizes(
+        :google_client_email,
+        :google_key_location,
+        :google_key_string,
+        :google_client,
+        :app_name,
+        :app_version,
+        :google_json_key_location,
+        :google_json_key_string
+      )
 
       # https://cloud.google.com/storage/docs/json_api/v1/
       GOOGLE_STORAGE_JSON_API_VERSION = "v1"

--- a/lib/fog/storage/google_json.rb
+++ b/lib/fog/storage/google_json.rb
@@ -7,13 +7,13 @@ module Fog
 
       requires :google_project
       recognizes(
-        :google_client_email,
-        :google_key_location,
-        :google_key_string,
-        :google_client,
-        :google_client_options,
         :app_name,
         :app_version,
+        :google_client,
+        :google_client_email,
+        :google_client_options,
+        :google_key_location,
+        :google_key_string,
         :google_json_key_location,
         :google_json_key_string
       )

--- a/lib/fog/storage/google_json.rb
+++ b/lib/fog/storage/google_json.rb
@@ -11,6 +11,7 @@ module Fog
         :google_key_location,
         :google_key_string,
         :google_client,
+        :google_client_options,
         :app_name,
         :app_version,
         :google_json_key_location,


### PR DESCRIPTION
Cleaned up the recognizes option a bit and added :google_client_options to suppress warning.

Fixes #197 