### PR TITLE
Tweak what versions we build and what OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: ruby
 cache: bundler
 sudo: false
+dist: trusty
 matrix:
   fast_finish: true
   include:
     - rvm: 2.1
     - rvm: 2.2
-    - rvm: 2.3.0
-    - rvm: 2.3.1
+    - rvm: 2.3
     - rvm: 2.4.0
+    - rvm: 2.4.1
     - rvm: jruby-head
   allow_failures:
     - rvm: jruby-head
-    - rvm: 2.4.0
+    - rvm: 2.4.1
 notifications:
   email: false


### PR DESCRIPTION
We now build on Trusty instead of Precise.

Limiting to just one version of 2.3, and major versions of 2.4.