### PR TITLE
check if push_config is present before checking for entries

### DIFF
--- a/lib/fog/google/requests/pubsub/create_subscription.rb
+++ b/lib/fog/google/requests/pubsub/create_subscription.rb
@@ -26,7 +26,7 @@ module Fog
             "topic" => (topic.is_a?(Topic) ? topic.name : topic.to_s)
           }
 
-          unless push_config.empty?
+          if push_config && push_config.any?
             body["pushConfig"] = push_config
           end
 


### PR DESCRIPTION
I'm getting 
```
[NoMethodError]: undefined method `empty?' for nil:NilClass
/opt/rh/cfme-gemset/gems/fog-google-0.5.2/lib/fog/google/requests/pubsub/create_subscription.rb:29:in `create_subscription'
/opt/rh/cfme-gemset/gems/fog-google-0.5.2/lib/fog/google/models/pubsub/subscription.rb:71:in `save'
/opt/rh/cfme-gemset/gems/fog-core-1.43.0/lib/fog/core/collection.rb:51:in `create'
```

The calling code is 
```ruby
google.subscriptions.create(:name  => subscription_name, :topic => topic_name)
```

My guess is either https://github.com/fog/fog-google/pull/168 introduced this regression because [this line](https://github.com/fog/fog-google/blob/4ac58a77f91f4d6877d77133b6bcee33403951d8/lib/fog/google/models/pubsub/subscription.rb#L71) passes `push_config` and if it's `nil` it will pass `nil`.

Adding `push_config => {}` to the caller fixes the issue.

this fixes https://github.com/fog/fog-google/issues/214

I'm not sure how and where to add a test for this. Seems this code path is not tested / covered at all :(
If you point me to a similar test, I can add it