### PR TITLE
Don't fail if no items

### DIFF
--- a/lib/fog/storage/google_json/models/files.rb
+++ b/lib/fog/storage/google_json/models/files.rb
@@ -16,7 +16,7 @@ module Fog
 
         def all(options = {})
           requires :directory
-          
+
           body = service.list_objects(directory.key, options).body
           load(body["items"] || [])
         end
@@ -41,8 +41,8 @@ module Fog
           data.headers.each do |k, v|
             file_data[k] = v
           end
-          file_data.merge!(:body => data.body,
-                           :key  => key)
+          file_data[:body] = data.body
+          file_data[:key] = key
           new(file_data)
         rescue Fog::Errors::NotFound
           nil

--- a/lib/fog/storage/google_json/models/files.rb
+++ b/lib/fog/storage/google_json/models/files.rb
@@ -16,8 +16,9 @@ module Fog
 
         def all(options = {})
           requires :directory
-
-          load(service.list_objects(directory.key, options)[:body]["items"])
+          
+          body = service.list_objects(directory.key, options).body
+          load(body["items"] || [])
         end
 
         alias_method :each_file_this_page, :each


### PR DESCRIPTION
```ruby
#! /usr/bin/env ruby
#
# create a fog connection, list buckets

require "bundler"
Bundler.require(:default, :development)

connection = Fog::Storage::Google.new({
  google_project: 'icco-fog-test',
  google_client_email: 'test-account@icco-fog-test.iam.gserviceaccount.com',
  google_json_key_location: './key.json'})

dir = connection.directories.get('pivotal-ally-6679')
p dir.files.all()
```

If you go and create a new empty bucket and run the above snippet, your code will throw 

```
/Users/natwelch/.rvm/gems/ruby-2.4.0/gems/fog-core-1.44.3/lib/fog/core/collection.rb:76:in `load': undefined method `each' for nil:NilClass (NoMethodError)
	from /Users/natwelch/.rvm/gems/ruby-2.4.0/gems/fog-google-0.5.3/lib/fog/storage/google_json/models/files.rb:20:in `all'
	from ./test-storage.rb:18:in `<main>'
```

Updated, it now returns 

```
  <Fog::Storage::GoogleJSON::Files
    common_prefixes=nil,
    delimiter=nil,
    directory=    <Fog::Storage::GoogleJSON::Directory
      key="pivotal-ally-6679"
    >,
    page_token=nil,
    max_results=nil,
    prefix=nil
    [

    ]
  >
```