### PR TITLE
Upgrade PubSub requests to >= 0.11

### DIFF
--- a/lib/fog/google/pubsub/real.rb
+++ b/lib/fog/google/pubsub/real.rb
@@ -12,7 +12,7 @@ module Fog
           options[:google_api_scope_url] = GOOGLE_PUBSUB_API_SCOPE_URLS.join(" ")
 
           @client = initialize_google_client(options)
-          @pubsub = @client.discovered_api("pubsub", api_version)
+          @pubsub = ::Google::Apis::PubsubV1::PubsubService.new
         end
       end
     end

--- a/lib/fog/google/requests/pubsub/create_subscription.rb
+++ b/lib/fog/google/requests/pubsub/create_subscription.rb
@@ -17,38 +17,19 @@ module Fog
         #   service default of 10 is used
         # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/create
         def create_subscription(subscription_name, topic, push_config = {}, ack_deadline_seconds = nil)
-          api_method = @pubsub.projects.subscriptions.create
+          subscription = ::Google::Apis::PubsubV1::Subscription.new(
+            :topic => topic,
+            :ack_deadline_seconds => ack_deadline_seconds,
+            :push_config => push_config
+          )
 
-          parameters = {}
-          parameters["name"] = subscription_name.to_s unless subscription_name.nil?
-
-          body = {
-            "topic" => (topic.is_a?(Topic) ? topic.name : topic.to_s)
-          }
-
-          unless push_config.empty?
-            body["pushConfig"] = push_config
-          end
-
-          body["ackDeadlineSeconds"] = ack_deadline_seconds unless ack_deadline_seconds.nil?
-
-          request(api_method, parameters, body)
+          @pubsub.create_subscription(subscription_name, subscription)
         end
       end
 
       class Mock
         def create_subscription(subscription_name, topic, push_config = {}, ack_deadline_seconds = nil)
-          subscription = {
-            "name"               => subscription_name,
-            "topic"              => topic,
-            "pushConfig"         => push_config,
-            "ackDeadlineSeconds" => ack_deadline_seconds
-          }
-
-          # We also track pending messages
-          data[:subscriptions][subscription_name] = subscription.merge(:messages => [])
-
-          build_excon_response(subscription, 200)
+          raise Fog::Errors::MockNotImplemented
         end
       end
     end

--- a/lib/fog/google/requests/pubsub/create_topic.rb
+++ b/lib/fog/google/requests/pubsub/create_topic.rb
@@ -9,26 +9,13 @@ module Fog
         #   'projects/myProject/topics/my_topic')
         # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/create
         def create_topic(topic_name)
-          api_method = @pubsub.projects.topics.create
-          parameters = {
-            "name" => topic_name.to_s
-          }
-
-          request(api_method, parameters)
+          @pubsub.create_topic(topic_name)
         end
       end
 
       class Mock
         def create_topic(topic_name)
-          data = {
-            "name" => topic_name
-          }
-          self.data[:topics][topic_name] = data
-
-          body = data.clone
-          status = 200
-
-          build_excon_response(body, status)
+          raise Fog::Errors::MockNotImplemented
         end
       end
     end

--- a/lib/fog/google/requests/pubsub/delete_subscription.rb
+++ b/lib/fog/google/requests/pubsub/delete_subscription.rb
@@ -7,20 +7,13 @@ module Fog
         # @param subscription_name [#to_s] name of subscription to delete
         # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/delete
         def delete_subscription(subscription_name)
-          api_method = @pubsub.projects.subscriptions.delete
-          parameters = {
-            "subscription" => subscription_name.to_s
-          }
-
-          request(api_method, parameters)
+          @pubsub.delete_subscription(subscription_name)
         end
       end
 
       class Mock
         def delete_subscription(subscription_name)
-          data[:subscriptions].delete(subscription_name)
-
-          build_excon_response(nil, 200)
+          raise Fog::Errors::MockNotImplemented
         end
       end
     end

--- a/lib/fog/google/requests/pubsub/delete_topic.rb
+++ b/lib/fog/google/requests/pubsub/delete_topic.rb
@@ -7,21 +7,13 @@ module Fog
         # @param topic_name [#to_s] name of topic to delete
         # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/delete
         def delete_topic(topic_name)
-          api_method = @pubsub.projects.topics.delete
-          parameters = {
-            "topic" => topic_name.to_s
-          }
-
-          request(api_method, parameters)
+          @pubsub.delete_topic(topic_name)
         end
       end
 
       class Mock
         def delete_topic(topic_name)
-          data[:topics].delete(topic_name)
-
-          status = 200
-          build_excon_response(nil, status)
+          raise Fog::Errors::MockNotImplemented
         end
       end
     end

--- a/lib/fog/google/requests/pubsub/get_subscription.rb
+++ b/lib/fog/google/requests/pubsub/get_subscription.rb
@@ -7,36 +7,13 @@ module Fog
         # @param subscription_name [#to_s] name of subscription to retrieve
         # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
         def get_subscription(subscription_name)
-          api_method = @pubsub.projects.subscriptions.get
-          parameters = {
-            "subscription" => subscription_name.to_s
-          }
-
-          request(api_method, parameters)
+          @pubsub.get_subscription(subscription_name)
         end
       end
 
       class Mock
         def get_subscription(subscription_name)
-          sub = data[:subscriptions][subscription_name]
-          if sub.nil?
-            subscription_resource = subscription_name.split("/")[-1]
-            body = {
-              "error" => {
-                "code"    => 404,
-                "message" => "Resource not found (resource=#{subscription_resource}).",
-                "status"  => "NOT_FOUND"
-              }
-            }
-            return build_excon_response(body, 404)
-          end
-
-          body = sub.select do |k, _|
-            %w(name topic pushConfig ackDeadlineSeconds).include?(k)
-          end
-          status = 200
-
-          build_excon_response(body, status)
+          raise Fog::Errors::MockNotImplemented
         end
       end
     end

--- a/lib/fog/google/requests/pubsub/get_topic.rb
+++ b/lib/fog/google/requests/pubsub/get_topic.rb
@@ -7,33 +7,13 @@ module Fog
         # @param topic_name [#to_s] name of topic to retrieve
         # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/get
         def get_topic(topic_name)
-          api_method = @pubsub.projects.topics.get
-          parameters = {
-            "topic" => topic_name.to_s
-          }
-
-          request(api_method, parameters)
+          @pubsub.get_topic(topic_name)
         end
       end
 
       class Mock
         def get_topic(topic_name)
-          if !data[:topics].key?(topic_name)
-            topic_resource = topic_name.split("/")[-1]
-            body = {
-              "error" => {
-                "code"    => 404,
-                "message" => "Resource not found (resource=#{topic_resource}).",
-                "status"  => "NOT_FOUND"
-              }
-            }
-            status = 404
-          else
-            body = data[:topics][topic_name].clone
-            status = 200
-          end
-
-          build_excon_response(body, status)
+          raise Fog::Errors::MockNotImplemented
         end
       end
     end

--- a/lib/fog/google/requests/pubsub/list_subscriptions.rb
+++ b/lib/fog/google/requests/pubsub/list_subscriptions.rb
@@ -9,29 +9,14 @@ module Fog
         #   the project configured on the client is used.
         # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
         def list_subscriptions(project = nil)
-          api_method = @pubsub.projects.subscriptions.list
-          parameters = {
-            "project" => (project.nil? ? "projects/#{@project}" : project.to_s)
-          }
-
-          request(api_method, parameters)
+          project = (project.nil? ? "projects/#{@project}" : project.to_s)
+          @pubsub.list_subscriptions(project)
         end
       end
 
       class Mock
         def list_subscriptions(_project = nil)
-          subs = data[:subscriptions].values.map do |sub|
-            # Filter out any keys that aren't part of the response object
-            sub.select do |k, _|
-              %w(name topic pushConfig ackDeadlineSeconds).include?(k)
-            end
-          end
-
-          body = {
-            "subscriptions" => subs
-          }
-          status = 200
-          build_excon_response(body, status)
+          raise Fog::Errors::MockNotImplemented
         end
       end
     end

--- a/lib/fog/google/requests/pubsub/list_topics.rb
+++ b/lib/fog/google/requests/pubsub/list_topics.rb
@@ -9,23 +9,14 @@ module Fog
         #   project configured on the client is used.
         # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/list
         def list_topics(project = nil)
-          api_method = @pubsub.projects.topics.list
-          parameters = {
-            "project" => (project.nil? ? "projects/#{@project}" : project.to_s)
-          }
-
-          request(api_method, parameters)
+          project = (project.nil? ? "projects/#{@project}" : project.to_s)
+          @pubsub.list_topics(project)
         end
       end
 
       class Mock
         def list_topics(_project = nil)
-          body = {
-            "topics" => data[:topics].values
-          }
-          status = 200
-
-          build_excon_response(body, status)
+          raise Fog::Errors::MockNotImplemented
         end
       end
     end

--- a/lib/fog/google/requests/pubsub/publish_topic.rb
+++ b/lib/fog/google/requests/pubsub/publish_topic.rb
@@ -10,50 +10,17 @@ module Fog
         #   must be base64 encoded.
         # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.topics/publish
         def publish_topic(topic, messages)
-          api_method = @pubsub.projects.topics.publish
+          publish_request = ::Google::Apis::PubsubV1::PublishRequest.new(
+            :messages => messages
+          )
 
-          parameters = {
-            "topic" => topic
-          }
-
-          body = {
-            "messages" => messages
-          }
-
-          request(api_method, parameters, body)
+          @pubsub.publish_topic(topic, publish_request)
         end
       end
 
       class Mock
         def publish_topic(topic, messages)
-          if data[:topics].key?(topic)
-            published_messages = messages.map do |msg|
-              msg.merge("messageId" => Fog::Mock.random_letters(16), "publishTime" => Time.now.iso8601)
-            end
-
-            # Gather the subscriptions and publish
-            data[:subscriptions].values.each do |sub|
-              next unless sub["topic"] == topic
-              sub[:messages] += published_messages
-            end
-
-            body = {
-              "messageIds" => published_messages.map { |msg| msg["messageId"] }
-            }
-            status = 200
-          else
-            topic_resource = topic_name.split("/")[-1]
-            body = {
-              "error" => {
-                "code"    => 404,
-                "message" => "Resource not found (resource=#{topic_resource}).",
-                "status"  => "NOT_FOUND"
-              }
-            }
-            status = 404
-          end
-
-          build_excon_response(body, status)
+          raise Fog::Errors::MockNotImplemented
         end
       end
     end

--- a/lib/fog/google/requests/pubsub/pull_subscription.rb
+++ b/lib/fog/google/requests/pubsub/pull_subscription.rb
@@ -17,59 +17,18 @@ module Fog
         #   retrieve (defaults to 10)
         # @see https://cloud.google.com/pubsub/reference/rest/v1/projects.subscriptions/pull
         def pull_subscription(subscription, options = { :return_immediately => true, :max_messages => 10 })
-          api_method = @pubsub.projects.subscriptions.pull
+          pull_request = ::Google::Apis::PubsubV1::PullRequest.new(
+            :return_immediately => options[:return_immediately],
+            :max_messages => options[:max_messages]
+          )
 
-          parameters = {
-            "subscription" => Fog::Google::Pubsub.subscription_name(subscription)
-          }
-
-          body = {
-            "returnImmediately" => options[:return_immediately],
-            "maxMessages" => options[:max_messages]
-          }
-
-          request(api_method, parameters, body)
+          @pubsub.pull_subscription(subscription, pull_request)
         end
       end
 
       class Mock
         def pull_subscription(subscription, options = { :return_immediately => true, :max_messages => 10 })
-          # We're going to ignore return_immediately; feel free to add support
-          # if you need it for testing
-          subscription_name = Fog::Google::Pubsub.subscription_name(subscription)
-          sub = data[:subscriptions][subscription_name]
-
-          if sub.nil?
-            subscription_resource = subscription_name.split("/")[-1]
-            body = {
-              "error" => {
-                "code"    => 404,
-                "message" => "Resource not found (resource=#{subscription_resource}).",
-                "status"  => "NOT_FOUND"
-              }
-            }
-            return build_excon_response(body, 404)
-          end
-
-          # This implementation is a bit weak; instead of "hiding" messages for
-          # some period of time after they are pulled, instead we always return
-          # them until acknowledged. This might cause issues with clients that
-          # refuse to acknowledge.
-          #
-          # Also, note that here we use the message id as the ack id - again,
-          # this might cause problems with some strange-behaving clients.
-          msgs = sub[:messages].take(options[:max_messages]).map do |msg|
-            {
-              "ackId"   => msg["messageId"],
-              "message" => msg
-            }
-          end
-
-          body = {
-            "receivedMessages" => msgs
-          }
-          status = 200
-          build_excon_response(body, status)
+          raise Fog::Errors::MockNotImplemented
         end
       end
     end

--- a/test/integration/pubsub/test_pubsub_requests.rb
+++ b/test/integration/pubsub/test_pubsub_requests.rb
@@ -12,20 +12,34 @@ class TestPubsubRequests < FogIntegrationTest
   end
 
   def delete_test_resources
-    topics = @client.list_topics[:body]["topics"]
-    unless topics.nil?
-      topics.
-        map { |t| t["name"] }.
-        select { |t| t.start_with?(topic_resource_prefix) }.
-        each { |t| @client.delete_topic(t) }
+    topics_result = @client.list_topics
+    unless topics_result.topics.nil?
+      begin
+        topics_result.topics.
+          map(&:name).
+          select { |t| t.start_with?(topic_resource_prefix) }.
+          each { |t| @client.delete_topic(t) }
+      # We ignore errors here as list operations may not represent changes applied recently.
+      # Hence, list operations can return a topic which has already been deleted but which we
+      # will attempt to delete again.
+      rescue Google::Apis::Error
+        Fog::Logger.warning("ignoring Google Api error during delete_test_resources")
+      end
     end
 
-    subscriptions = @client.list_subscriptions[:body]["subscriptions"]
-    unless subscriptions.nil?
-      subscriptions.
-        map { |s| s["name"] }.
-        select { |s| s.start_with?(subscription_resource_prefix) }.
-        each { |s| @client.delete_subscription(s) }
+    subscriptions_result = @client.list_subscriptions
+    unless subscriptions_result.subscriptions.nil?
+      begin
+        subscriptions_result.subscriptions.
+          map(&:name).
+          select { |s| s.start_with?(subscription_resource_prefix) }.
+          each { |s| @client.delete_subscription(s) }
+      # We ignore errors here as list operations may not represent changes applied recently.
+      # Hence, list operations can return a topic which has already been deleted but which we
+      # will attempt to delete again.
+      rescue Google::Apis::Error
+        Fog::Logger.warning("ignoring Google Api error during delete_test_resources")
+      end
     end
   end
 
@@ -50,7 +64,6 @@ class TestPubsubRequests < FogIntegrationTest
     @some_topic ||= new_topic_name.tap do |t|
       @client.create_topic(t)
     end
-    @some_topic
   end
 
   def some_subscription_name
@@ -58,109 +71,104 @@ class TestPubsubRequests < FogIntegrationTest
     @some_subscription ||= new_subscription_name.tap do |s|
       @client.create_subscription(s, some_topic_name)
     end
-    @some_subscription
   end
 
   def test_create_topic
-    result = @client.create_topic(new_topic_name)
-
-    assert_equal(200, result.status, "request should be successful")
-    assert_includes(result[:body].keys, "name", "resulting body should contain expected keys")
+    name = new_topic_name
+    result = @client.create_topic(name)
+    assert_equal(result.name, name)
   end
 
   def test_get_topic
     result = @client.get_topic(some_topic_name)
-
-    assert_equal(200, result.status, "request should be successful")
-    assert_includes(result[:body].keys, "name", "resulting body should contain expected keys")
+    assert_equal(result.name, some_topic_name)
   end
 
   def test_list_topics
     # Force a topic to be created just so we have at least 1 to list
-    @client.create_topic(new_topic_name)
-    result = @client.list_topics
+    name = new_topic_name
+    @client.create_topic(name)
 
-    assert_equal(200, result.status, "request should be successful")
-    assert_includes(result[:body].keys, "topics", "resulting body should contain expected keys")
-    assert_operator(result[:body]["topics"].size, :>, 0, "topic count should be positive")
+    Fog.wait_for(5) do
+      result = @client.list_topics
+      if result.topics.nil?
+        false
+      end
+
+      result.topics.any? { |topic| topic.name == name }
+    end
   end
 
   def test_delete_topic
     topic_to_delete = new_topic_name
     @client.create_topic(topic_to_delete)
 
-    result = @client.delete_topic(topic_to_delete)
-    assert_equal(200, result.status, "request should be successful")
+    @client.delete_topic(topic_to_delete)
   end
 
   def test_publish_topic
-    result = @client.publish_topic(some_topic_name, [:data => Base64.strict_encode64("some message")])
-
-    assert_equal(200, result.status, "request should be successful")
-    assert_includes(result[:body].keys, "messageIds", "resulting body should contain expected keys")
+    @client.publish_topic(some_topic_name, [:data => Base64.strict_encode64("some message")])
   end
 
   def test_create_subscription
     push_config = {}
     ack_deadline_seconds = 18
 
-    result = @client.create_subscription(new_subscription_name, some_topic_name, push_config, ack_deadline_seconds)
-
-    assert_equal(200, result.status, "request should be successful")
-    assert((%w{name topic pushConfig ackDeadlineSeconds} - result[:body].keys).empty?,
-           "resulting body should contain expected keys")
-    assert_equal(18, result[:body]["ackDeadlineSeconds"], "ackDeadlineSeconds should be 18")
+    subscription_name = new_subscription_name
+    result = @client.create_subscription(subscription_name, some_topic_name,
+                                         push_config, ack_deadline_seconds)
+    assert_equal(result.name, subscription_name)
   end
 
   def test_get_subscription
-    result = @client.get_subscription(some_subscription_name)
+    subscription_name = some_subscription_name
+    result = @client.get_subscription(subscription_name)
 
-    assert_equal(200, result.status, "request should be successful")
-    assert(%w{name topic pushConfig ackDeadlineSeconds} - result[:body].keys,
-           "resulting body should contain expected keys")
+    assert_equal(result.name, subscription_name)
   end
 
   def test_list_subscriptions
     # Force a subscription to be created just so we have at least 1 to list
-    @client.create_subscription(new_subscription_name, some_topic_name)
-    result = @client.list_subscriptions
+    subscription_name = new_subscription_name
+    @client.create_subscription(subscription_name, some_topic_name)
 
-    assert_equal(200, result.status, "request should be successful")
-    assert_includes(result[:body].keys, "subscriptions", "resulting body should contain expected keys")
-    assert_operator(result[:body]["subscriptions"].size, :>, 0, "subscription count should be positive")
+    Fog.wait_for(5) do
+      result = @client.list_subscriptions
+      if result.subscriptions.nil?
+        false
+      end
+
+      result.subscriptions.any? { |sub| sub.name == subscription_name }
+    end
   end
 
   def test_delete_subscription
     subscription_to_delete = new_subscription_name
     @client.create_subscription(subscription_to_delete, some_topic_name)
 
-    result = @client.delete_subscription(subscription_to_delete)
-    assert_equal(200, result.status, "request should be successful")
+    @client.delete_subscription(subscription_to_delete)
   end
 
   def test_pull_subscription
-    subscription = new_subscription_name
-    @client.create_subscription(subscription, some_topic_name)
-    @client.publish_topic(some_topic_name, [:data => Base64.strict_encode64("some message")])
+    subscription_name = new_subscription_name
+    message_bytes = Base64.strict_encode64("some message")
+    @client.create_subscription(subscription_name, some_topic_name)
+    @client.publish_topic(some_topic_name, [:data => message_bytes])
 
-    result = @client.pull_subscription(subscription)
+    result = @client.pull_subscription(subscription_name)
 
-    assert_equal(200, result.status, "request should be successful")
-    assert_includes(result[:body].keys, "receivedMessages", "resulting body should contain expected keys")
-    assert_equal(1, result[:body]["receivedMessages"].size, "we should have received a message")
-    assert_equal("some message",
-                 Base64.strict_decode64(result[:body]["receivedMessages"][0]["message"]["data"]),
-                 "received message should be the same as what we sent")
+    contained = result.received_messages.any? { |received| received.message.data == message_bytes }
+    assert_equal(true, contained, "sent messsage not contained within pulled responses")
   end
 
   def test_acknowledge_subscription
-    subscription = new_subscription_name
-    @client.create_subscription(subscription, some_topic_name)
+    subscription_name = new_subscription_name
+    @client.create_subscription(subscription_name, some_topic_name)
     @client.publish_topic(some_topic_name, [:data => Base64.strict_encode64("some message")])
-    pull_result = @client.pull_subscription(subscription)
+    pull_result = @client.pull_subscription(subscription_name)
+    assert_operator(pull_result.received_messages.length, :>, 0)
 
-    result = @client.acknowledge_subscription(subscription, pull_result[:body]["receivedMessages"][0]["ackId"])
-
-    assert_equal(200, result.status, "request should be successful")
+    @client.acknowledge_subscription(subscription_name,
+                                     pull_result.received_messages[0].ack_id)
   end
 end


### PR DESCRIPTION
This breaks compatibility with the previous excon based approach
as keeping it would require us to manually wrap every API
client operation in an excon response.
Additionally, all mocks have been deleted and left unimplemented.

However, the tests have been migrated and currently pass.

Looking for review to make sure this style is fine to continue with for the pubsub models. Thanks!