### PR TITLE
Upgrade PubSub models to >= 0.11

### DIFF
--- a/lib/fog/google/models/pubsub/subscription.rb
+++ b/lib/fog/google/models/pubsub/subscription.rb
@@ -30,17 +30,17 @@ module Fog
         def pull(options = { :return_immediately => true, :max_messages => 10 })
           requires :name
 
-          data = service.pull_subscription(name, options).body
+          data = service.pull_subscription(name, options).to_h
 
-          return [] unless data.key?("receivedMessages")
+          return [] unless data.key?(:received_messages)
           # Turn into a list of ReceivedMessage, but ensure we perform a base64 decode first
-          data["receivedMessages"].map do |recv_message|
+          data[:received_messages].map do |recv_message|
             attrs = {
               :service => service,
               :subscription_name => name
             }.merge(recv_message)
 
-            attrs["message"]["data"] = Base64.decode64(recv_message["message"]["data"]) if recv_message["message"].key?("data")
+            attrs[:message][:data] = Base64.decode64(recv_message[:message][:data]) if recv_message[:message].key?(:data)
             ReceivedMessage.new(attrs)
           end
         end
@@ -68,7 +68,7 @@ module Fog
         def save
           requires :name, :topic
 
-          data = service.create_subscription(name, topic, push_config, ack_deadline_seconds).body
+          data = service.create_subscription(name, topic, push_config, ack_deadline_seconds).to_h
           merge_attributes(data)
         end
 

--- a/lib/fog/google/models/pubsub/subscriptions.rb
+++ b/lib/fog/google/models/pubsub/subscriptions.rb
@@ -12,7 +12,7 @@ module Fog
         # @return [Array<Fog::Google::Pubsub::Subscription>] list of
         #   subscriptions
         def all
-          data = service.list_subscriptions.body["subscriptions"] || []
+          data = service.list_subscriptions.to_h[:subscriptions] || []
           load(data)
         end
 
@@ -21,7 +21,7 @@ module Fog
         # @param subscription_name [String] name of subscription to retrieve
         # @return [Fog::Google::Pubsub::Topic] topic found, or nil if not found
         def get(subscription_name)
-          subscription = service.get_subscription(subscription_name).body
+          subscription = service.get_subscription(subscription_name).to_h
           new(subscription)
         rescue Fog::Errors::NotFound
           nil

--- a/lib/fog/google/models/pubsub/topic.rb
+++ b/lib/fog/google/models/pubsub/topic.rb
@@ -47,18 +47,17 @@ module Fog
           messages.each do |message|
             encoded_message = {}
             if message.is_a?(Hash)
-              encoded_message["attributes"] = message["attributes"]
               if message.key?("data")
-                encoded_message["data"] = Base64.strict_encode64(message["data"])
+                encoded_message[:data] = Base64.strict_encode64(message["data"])
               end
             else
-              encoded_message["data"] = Base64.strict_encode64(message.to_s)
+              encoded_message[:data] = Base64.strict_encode64(message.to_s)
             end
 
             encoded_messages << encoded_message
           end
 
-          service.publish_topic(name, encoded_messages).body["messageIds"]
+          service.publish_topic(name, encoded_messages).to_h[:message_ids]
         end
 
         # Save the instance (does the same thing as #create)

--- a/lib/fog/google/models/pubsub/topics.rb
+++ b/lib/fog/google/models/pubsub/topics.rb
@@ -11,7 +11,7 @@ module Fog
         #
         # @return [Array<Fog::Google::Pubsub::Topic>] list of topics
         def all
-          data = service.list_topics.body["topics"] || []
+          data = service.list_topics.to_h[:topics] || []
           load(data)
         end
 
@@ -20,7 +20,7 @@ module Fog
         # @param topic_name [String] name of topic to retrieve
         # @return [Fog::Google::Pubsub::Topic] topic found, or nil if not found
         def get(topic_name)
-          topic = service.get_topic(topic_name).body
+          topic = service.get_topic(topic_name).to_h
           new(topic)
         rescue Fog::Errors::NotFound
           nil

--- a/test/integration/pubsub/pubsub_shared.rb
+++ b/test/integration/pubsub/pubsub_shared.rb
@@ -1,0 +1,75 @@
+require "helpers/integration_test_helper"
+require "securerandom"
+require "base64"
+
+class PubSubShared < FogIntegrationTest
+  def setup
+    @client = Fog::Google::Pubsub.new
+    # Ensure any resources we create with test prefixes are removed
+    Minitest.after_run do
+      delete_test_resources
+    end
+  end
+
+  def delete_test_resources
+    topics_result = @client.list_topics
+    unless topics_result.topics.nil?
+      begin
+        topics_result.topics.
+          map(&:name).
+          select { |t| t.start_with?(topic_resource_prefix) }.
+          each { |t| @client.delete_topic(t) }
+      # We ignore errors here as list operations may not represent changes applied recently.
+      # Hence, list operations can return a topic which has already been deleted but which we
+      # will attempt to delete again.
+      rescue Google::Apis::Error
+        Fog::Logger.warning("ignoring Google Api error during delete_test_resources")
+      end
+    end
+
+    subscriptions_result = @client.list_subscriptions
+    unless subscriptions_result.subscriptions.nil?
+      begin
+        subscriptions_result.subscriptions.
+          map(&:name).
+          select { |s| s.start_with?(subscription_resource_prefix) }.
+          each { |s| @client.delete_subscription(s) }
+      # We ignore errors here as list operations may not represent changes applied recently.
+      # Hence, list operations can return a topic which has already been deleted but which we
+      # will attempt to delete again.
+      rescue Google::Apis::Error
+        Fog::Logger.warning("ignoring Google Api error during delete_test_resources")
+      end
+    end
+  end
+
+  def topic_resource_prefix
+    "projects/#{@client.project}/topics/fog-integration-test"
+  end
+
+  def subscription_resource_prefix
+    "projects/#{@client.project}/subscriptions/fog-integration-test"
+  end
+
+  def new_topic_name
+    "#{topic_resource_prefix}-#{SecureRandom.uuid}"
+  end
+
+  def new_subscription_name
+    "#{subscription_resource_prefix}-#{SecureRandom.uuid}"
+  end
+
+  def some_topic_name
+    # create lazily to speed tests up
+    @some_topic ||= new_topic_name.tap do |t|
+      @client.create_topic(t)
+    end
+  end
+
+  def some_subscription_name
+    # create lazily to speed tests up
+    @some_subscription ||= new_subscription_name.tap do |s|
+      @client.create_subscription(s, some_topic_name)
+    end
+  end
+end

--- a/test/integration/pubsub/test_pubsub_models.rb
+++ b/test/integration/pubsub/test_pubsub_models.rb
@@ -1,0 +1,135 @@
+require "helpers/integration_test_helper"
+require "integration/pubsub/pubsub_shared"
+require "securerandom"
+require "base64"
+
+class TestPubsubModels < PubSubShared
+  def test_topics_create
+    name = new_topic_name
+    result = @client.topics.create(:name => name)
+    assert_equal(result.name, name)
+  end
+
+  def test_topics_get
+    result = @client.topics.get(some_topic_name)
+    assert_equal(result.name, some_topic_name)
+  end
+
+  def test_topics_all
+    # Force a topic to be created just so we have at least 1 to list
+    name = new_topic_name
+    @client.create_topic(name)
+
+    Fog.wait_for(5) do
+      result = @client.topics.all
+      if result.nil?
+        false
+      end
+
+      result.any? { |topic| topic.name == name }
+    end
+  end
+
+  def test_topic_publish_string
+    @client.topics.get(some_topic_name)
+    message_ids = @client.topics.get(some_topic_name).publish(["apples"])
+    assert_operator(message_ids.length, :>, 0)
+  end
+
+  def test_topic_publish_hash
+    @client.topics.get(some_topic_name)
+    message_ids = @client.topics.get(some_topic_name).publish(["data" => "apples"])
+    assert_operator(message_ids.length, :>, 0)
+  end
+
+  def test_topic_delete
+    topic_to_delete = new_topic_name
+    topic = @client.topics.create(:name => topic_to_delete)
+
+    topic.destroy
+  end
+
+  def test_subscriptions_create
+    push_config = {}
+    ack_deadline_seconds = 18
+
+    subscription_name = new_subscription_name
+    result = @client.subscriptions.create(:name => subscription_name,
+                                          :topic => some_topic_name,
+                                          :push_config => push_config,
+                                          :ack_deadline_seconds => ack_deadline_seconds)
+    assert_equal(result.name, subscription_name)
+  end
+
+  def test_subscriptions_get
+    subscription_name = some_subscription_name
+    result = @client.subscriptions.get(subscription_name)
+
+    assert_equal(result.name, subscription_name)
+  end
+
+  def test_subscriptions_list
+    # Force a subscription to be created just so we have at least 1 to list
+    subscription_name = new_subscription_name
+    @client.subscriptions.create(:name => subscription_name, :topic => some_topic_name)
+
+    Fog.wait_for(5) do
+      result = @client.subscriptions.all
+      if result.nil?
+        false
+      end
+
+      result.any? { |subscription| subscription.name == subscription_name }
+    end
+  end
+
+  def test_subscription_delete
+    push_config = {}
+    ack_deadline_seconds = 18
+
+    subscription_name = new_subscription_name
+    subscription = @client.subscriptions.create(:name => subscription_name,
+                                                :topic => some_topic_name,
+                                                :push_config => push_config,
+                                                :ack_deadline_seconds => ack_deadline_seconds)
+    subscription.destroy
+  end
+
+  def test_subscription_pull
+    subscription_name = new_subscription_name
+    message_bytes = Base64.strict_encode64("some message")
+    subscription = @client.subscriptions.create(:name => subscription_name,
+                                                :topic => some_topic_name)
+    @client.topics.get(some_topic_name).publish(["data" => message_bytes])
+
+    result = subscription.pull
+    assert_operator(result.length, :>, 0)
+
+    contained = result.any? { |received| received.message[:data] == message_bytes }
+    assert_equal(true, contained, "sent messsage not contained within pulled responses")
+  end
+
+  def test_subscription_acknowledge
+    subscription_name = new_subscription_name
+    subscription = @client.subscriptions.create(:name => subscription_name,
+                                                :topic => some_topic_name)
+    @client.topics.get(some_topic_name).publish(["data" => Base64.strict_encode64("some message")])
+
+    result = subscription.pull
+    assert_operator(result.length, :>, 0)
+
+    subscription.acknowledge([result[0].ack_id])
+  end
+
+  def test_message_acknowledge
+    subscription_name = new_subscription_name
+    subscription = @client.subscriptions.create(:name => subscription_name,
+                                                :topic => some_topic_name)
+    @client.topics.get(some_topic_name).publish(["data" => Base64.strict_encode64("some message")])
+
+    result = subscription.pull
+    assert_operator(result.length, :>, 0)
+
+    result[0].acknowledge
+  end
+end

--- a/test/integration/pubsub/test_pubsub_requests.rb
+++ b/test/integration/pubsub/test_pubsub_requests.rb
@@ -1,78 +1,9 @@
 require "helpers/integration_test_helper"
+require "integration/pubsub/pubsub_shared"
 require "securerandom"
 require "base64"
 
-class TestPubsubRequests < FogIntegrationTest
-  def setup
-    @client = Fog::Google::Pubsub.new
-    # Ensure any resources we create with test prefixes are removed
-    Minitest.after_run do
-      delete_test_resources
-    end
-  end
-
-  def delete_test_resources
-    topics_result = @client.list_topics
-    unless topics_result.topics.nil?
-      begin
-        topics_result.topics.
-          map(&:name).
-          select { |t| t.start_with?(topic_resource_prefix) }.
-          each { |t| @client.delete_topic(t) }
-      # We ignore errors here as list operations may not represent changes applied recently.
-      # Hence, list operations can return a topic which has already been deleted but which we
-      # will attempt to delete again.
-      rescue Google::Apis::Error
-        Fog::Logger.warning("ignoring Google Api error during delete_test_resources")
-      end
-    end
-
-    subscriptions_result = @client.list_subscriptions
-    unless subscriptions_result.subscriptions.nil?
-      begin
-        subscriptions_result.subscriptions.
-          map(&:name).
-          select { |s| s.start_with?(subscription_resource_prefix) }.
-          each { |s| @client.delete_subscription(s) }
-      # We ignore errors here as list operations may not represent changes applied recently.
-      # Hence, list operations can return a topic which has already been deleted but which we
-      # will attempt to delete again.
-      rescue Google::Apis::Error
-        Fog::Logger.warning("ignoring Google Api error during delete_test_resources")
-      end
-    end
-  end
-
-  def topic_resource_prefix
-    "projects/#{@client.project}/topics/fog-integration-test"
-  end
-
-  def subscription_resource_prefix
-    "projects/#{@client.project}/subscriptions/fog-integration-test"
-  end
-
-  def new_topic_name
-    "#{topic_resource_prefix}-#{SecureRandom.uuid}"
-  end
-
-  def new_subscription_name
-    "#{subscription_resource_prefix}-#{SecureRandom.uuid}"
-  end
-
-  def some_topic_name
-    # create lazily to speed tests up
-    @some_topic ||= new_topic_name.tap do |t|
-      @client.create_topic(t)
-    end
-  end
-
-  def some_subscription_name
-    # create lazily to speed tests up
-    @some_subscription ||= new_subscription_name.tap do |s|
-      @client.create_subscription(s, some_topic_name)
-    end
-  end
-
+class TestPubsubRequests < PubSubShared
   def test_create_topic
     name = new_topic_name
     result = @client.create_topic(name)


### PR DESCRIPTION
Models have been minimally changed to work against the rewritten
requests. Additionally, model tests have been included.

This follows up from the previous upgrade of the PubSub requests.
df470108cd944ec09d81cf56c6c556f339ba7dc8