### PR TITLE
Issue with signed urls and paths containing white spaces

### DIFF
--- a/lib/fog/storage/google_json/utils.rb
+++ b/lib/fog/storage/google_json/utils.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module Fog
   module Storage
     class GoogleJSON
@@ -19,7 +21,7 @@ module Fog
 
         def host_path_query(params, expires)
           params[:headers]["Date"] = expires.to_i
-          params[:path] = CGI.escape(params[:path]).gsub("%2F", "/")
+          params[:path] = URI.encode(params[:path]).gsub("%2F", "/")
           query = [params[:query]].compact
           query << "GoogleAccessId=#{@client.authorization.issuer}"
           query << "Signature=#{CGI.escape(signature(params))}"

--- a/lib/fog/storage/google_xml/utils.rb
+++ b/lib/fog/storage/google_xml/utils.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module Fog
   module Storage
     class GoogleXML

--- a/lib/fog/storage/google_xml/utils.rb
+++ b/lib/fog/storage/google_xml/utils.rb
@@ -19,7 +19,7 @@ module Fog
 
         def host_path_query(params, expires)
           params[:headers]["Date"] = expires.to_i
-          params[:path] = CGI.escape(params[:path]).gsub("%2F", "/")
+          params[:path] = URI.encode(params[:path]).gsub("%2F", "/")
           query = [params[:query]].compact
           query << "GoogleAccessId=#{@google_storage_access_key_id}"
           query << "Signature=#{CGI.escape(signature(params))}"

--- a/test/integration/storage/test_files.rb
+++ b/test/integration/storage/test_files.rb
@@ -54,6 +54,13 @@ class TestFiles < FogIntegrationTest
     assert_match(/fog-smoke-test/, https_url)
     assert_match(/fog-testfile/, https_url)
   end
+  
+  def test_get_https_url
+    https_url = @directory.files.get_https_url("fog -testfile", (Time.now + 1.minute).to_i)
+    assert_match(/https/, https_url)
+    assert_match(/fog-smoke-test/, https_url)
+    assert_match(/fog\%20-testfile/, https_url)
+  end
 
   def test_head
     assert_instance_of Fog::Storage::Google::File, @directory.files.head("fog-testfile")


### PR DESCRIPTION
# What

We have experienced while using `paperclip` + `fog` + `fog-google` that files containing special characters (white space) where incorrectly translated to `+` char. This is because of CGI.escape usage instead of URI.encode.

CGI.scape does translate ` ` to `+` as in `https://` . And `+` means a space only in `application/x-www-form-urlencoded` content, such as the query parameter keys.

As we are forming urls as so:

```
https://storage.googleapis.com/MY_BUCKET/RANDOM NAME-with_chars.jpgGoogleAccessId=REDACTED&Signature=REDACTED&Expires=3600
```

this will endup being transformed to


```
https://storage.googleapis.com/MY_BUCKET/RANDOM+NAME-with_chars.jpgGoogleAccessId=REDACTED&Signature=REDACTED&Expires=3600
```

ending in `NoSuchKey` error. Instead of

```
https://storage.googleapis.com/MY_BUCKET/RANDOM%20NAME-with_chars.jpgGoogleAccessId=REDACTED&Signature=REDACTED&Expires=3600
```

what is the correct one.