### PR TITLE
Explicitly set rubocop TargetRubyVersion to 2.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ AllCops:
     - "vendor/**/*"
     - "db/schema.rb"
   UseCache: false
+  TargetRubyVersion: 2.1
 Style/CollectionMethods:
   Description: Preferred collection methods.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size


### PR DESCRIPTION
This is the lowest version of ruby travis is run against, so hound
should match to prevent version mismatches.

This will prevent hound from requesting changes which are
incompatible with versions we support. An example of such a
feature is safe navigation, not available before 2.3. ie,
github.com/fog/fog-google/pull/231#pullrequestreview-49858308