### PR TITLE
Introduce Concourse pipeline

### DIFF
--- a/ci/.gitignore
+++ b/ci/.gitignore
@@ -1,0 +1,1 @@
+credentials.yml

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,70 @@
+# fog-google CI
+
+This pipeline performs two functions.
+
+1. Performing an integration test of the
+upgrade-google-client branch whenever new changes appear there.
+
+1. Running integration tests against every PR with the
+`integrate` label. This allows whitelisted PRs to be tested
+automatically before being merged. Status is updated on the
+PR when the test completes.
+
+## Setup
+
+In order to run the fog-google Concourse Pipeline you must have an existing
+[Concourse](http://concourse.ci) environment.
+See [Deploying Concourse on Google Compute Engine](https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/blob/master/docs/deploy_concourse.md)
+for instructions.
+
+To deploy the pipeline:
+
+* Download the `fly` binary from the Concourse web interface and place it in your `$PATH`.
+
+* Login to your Concourse:
+
+```
+fly -t fog-google login -c <YOUR CONCOURSE URL>
+```
+
+* Update the [credentials.yml](https://github.com/fog/fog-google/blob/master/ci/credentials.yml.tpl)
+file. See [Credentials Requirements](#credentials-requirements) for specific instructions.
+
+* Set the fog-google pipeline:
+
+```
+fly -t fog-google set-pipeline -p fog-google -c pipeline.yml -l credentials.yml
+```
+
+* Unpause the fog-google pipeline:
+
+```
+fly -t fog-google unpause-pipeline -p fog-google
+```
+
+## Credentials Requirements
+
+Several external pieces of authentication are needed for credentials.yml
+
+1. A JSON Service Account File for a service account with at least Editor access to the project.
+    * To get a Service Account File, see [here](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#creatinganaccount) 
+      and create using the Project/Editor role.
+
+1. A [Github Access Token](https://github.com/blog/1509-personal-api-tokens) with at least
+`repo:status` access and a private key with push access to the `fog/fog-google` repositoy.
+
+These items are equivalent to your login credentials for their resources.
+
+## Login Gotchas
+
+* If your Concourse deployment is using a self-signed certificate, use `--insecure` to
+trust the provided certificate.
+
+* If logging into a specific team, ie `fog-google`, use `--team-name fog-google` to specify that.
+
+## Dockerfile
+
+The [docker-image](https://github.com/fog/fog-google/blob/master/ci/docker-image) directory contains
+the Dockerfile necessary for recreating the Docker image used in tasks. This is referenced
+in a per-task basis as `image_resource`, ie in
+image_resource [run-int.yml](https://github.com/fog/fog-google/blob/master/ci/tasks/run-int.yml)

--- a/ci/credentials.yml.tpl
+++ b/ci/credentials.yml.tpl
@@ -1,0 +1,13 @@
+---
+# Google Cloud Platform project to run under
+google_project:
+# Google Compute Engine Service Account email
+google_client_email:
+# Google Compute Engine Service Account JSON
+google_json_key_data: |
+
+# An access token with repo:status access
+github_access_token:
+# A SSH private key associated with the access token's account or
+# a repo push deploy key
+github_private_key: |

--- a/ci/docker-image/Dockerfile
+++ b/ci/docker-image/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:16.04
+
+# Packages
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y -qq update && apt-get -y -qq install \
+  build-essential \
+  curl \
+  git \
+  zlib1g-dev \
+  libssl-dev \
+  libreadline-dev \
+  libyaml-dev \
+  libxml2-dev \
+  libxslt-dev
+
+# Ubuntu 16.04 will fetch us 2.3.x without any issues.
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y -qq install ruby ruby-dev
+
+RUN apt-get clean
+
+RUN gem install bundler

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,63 @@
+jobs:
+  - name: base-int
+    plan:
+      - aggregate:
+        - {
+            get: fog-google-src, resource: fog-google-src-in, trigger: true
+          }
+
+      - task: full-integration-tests
+        file: fog-google-src/ci/tasks/run-int.yml
+        params:
+          google_project: {{google_project}}
+          google_json_key_data: {{google_json_key_data}}
+          google_client_email: {{google_client_email}}
+
+  - name: pr-int
+    plan:
+      - get: fog-google-src
+        resource: pull-request
+        version: every
+        trigger: true
+      - put: pull-request
+        params: {path: fog-google-src, status: pending}
+
+      - task: full-integration-tests
+        file: fog-google-src/ci/tasks/run-int.yml
+        params:
+          google_project: {{google_project}}
+          google_json_key_data: {{google_json_key_data}}
+          google_client_email: {{google_client_email}}
+        on_success:
+          put: pull-request
+          params:
+            path: fog-google-src
+            status: success
+        on_failure:
+          put: pull-request
+          params:
+            path: fog-google-src
+            status: failure
+
+resources:
+  - name: fog-google-src-in
+    type: git
+    source:
+      uri: https://github.com/fog/fog-google.git
+      branch: upgrade-google-client
+  - name: pull-request
+    type: pull-request
+    source:
+      access_token: {{github_access_token}}
+      private_key: {{github_private_key}}
+      label: integrate
+      repo: fog/fog-google
+
+resource_types:
+  # This is a third party resource.
+  # The referenced docker-image is maintained externally
+  # https://github.com/jtarchie/pullrequest-resource
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: jtarchie/pr

--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+my_dir="$( cd $(dirname $0) && pwd )"
+release_dir="$( cd ${my_dir} && cd ../.. && pwd )"
+workspace_dir="$( cd ${release_dir} && cd ../../../.. && pwd )"
+
+pushd ${release_dir} > /dev/null
+
+source ci/tasks/utils.sh
+
+popd > /dev/null
+
+check_param google_project
+check_param google_client_email
+check_param google_json_key_data
+
+echo $google_json_key_data > `pwd`/service_account_key.json
+
+cat >~/.fog <<EOL
+test:
+  google_project: ${google_project}
+  google_client_email: ${google_client_email}
+  google_json_key_location: `pwd`/service_account_key.json
+EOL
+
+pushd ${release_dir} > /dev/null
+
+bundle install
+
+FOG_MOCK=false rake test
+
+popd > /dev/null

--- a/ci/tasks/run-int.yml
+++ b/ci/tasks/run-int.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+image_resource:
+  type: docker-image
+  source: {repository: everlag/fog-google}
+inputs:
+- name: fog-google-src
+  path: src/fog-google
+run:
+  path: src/fog-google/ci/tasks/run-int.sh
+params:
+  google_project: replace-me
+  google_client_email: replace-me
+  google_json_key_data: |
+    replace-me

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+check_param() {
+  local name=$1
+  local value=$(eval echo '$'$name)
+  if [ "$value" == 'replace-me' ]; then
+    echo "environment variable $name must be set"
+    exit 1
+  fi
+}


### PR DESCRIPTION
This pipeline performs two functions.

First, it performs an integration test of the
upgrade-google-client branch whenever new changes appear there.

Second, it runs integration tests against every PR with the
`integrate` label. This allows whitelisted PRs to be tested
automatically before being merged. Status is updated on the
PR when the test completes.

When #210 lands, switch the pipeline to work against master.