### PR TITLE
Add google_auth to the list of recognized options

### DIFF
--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -8,6 +8,7 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_auth,
         :google_client,
         :google_client_email,
         :google_client_options,

--- a/lib/fog/dns/google.rb
+++ b/lib/fog/dns/google.rb
@@ -8,6 +8,7 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_auth,
         :google_client,
         :google_client_email,
         :google_client_options,

--- a/lib/fog/google/monitoring.rb
+++ b/lib/fog/google/monitoring.rb
@@ -8,6 +8,7 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_auth,
         :google_client,
         :google_client_email,
         :google_client_options,

--- a/lib/fog/google/pubsub.rb
+++ b/lib/fog/google/pubsub.rb
@@ -8,6 +8,7 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_auth,
         :google_client,
         :google_client_email,
         :google_client_options,

--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -20,6 +20,7 @@ module Fog
       # Initializes the Google API Client
       #
       # @param [Hash] options Google API options
+      # @option options [Google::Auth|Signet] :google_auth Manually created authorization to use
       # @option options [String] :google_client_email A @developer.gserviceaccount.com email address to use
       # @option options [String] :google_key_location The location of a pkcs12 key file
       # @option options [String] :google_key_string The content of the pkcs12 key file

--- a/lib/fog/google/sql.rb
+++ b/lib/fog/google/sql.rb
@@ -8,6 +8,7 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_auth,
         :google_client,
         :google_client_email,
         :google_client_options,

--- a/lib/fog/storage/google_json.rb
+++ b/lib/fog/storage/google_json.rb
@@ -9,6 +9,7 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_auth,
         :google_client,
         :google_client_email,
         :google_client_options,


### PR DESCRIPTION
Missed this in https://github.com/fog/fog-google/pull/211, gets rid of `[fog][WARNING] Unrecognized arguments: google_auth` warnings.