### PR TITLE
support for SSL certificates, https proxies and global IP addresses

### DIFF
--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -40,6 +40,7 @@ module Fog
       request :add_zone_view_resources
 
       request :delete_address
+      request :delete_global_address
       request :delete_backend_service
       request :delete_disk
       request :delete_firewall
@@ -65,6 +66,7 @@ module Fog
       request :delete_zone_view
 
       request :get_address
+      request :get_global_address
       request :get_backend_service
       request :get_backend_service_health
       request :get_disk
@@ -98,6 +100,7 @@ module Fog
       request :get_zone_view
 
       request :insert_address
+      request :insert_global_address
       request :insert_backend_service
       request :insert_disk
       request :insert_firewall
@@ -120,6 +123,7 @@ module Fog
       request :insert_zone_view
 
       request :list_addresses
+      request :lis_global_address
       request :list_aggregated_addresses
       request :list_aggregated_disk_types
       request :list_aggregated_disks
@@ -197,6 +201,9 @@ module Fog
 
       model :address
       collection :addresses
+
+      model :global_address
+      collection :global_addresses
 
       model :operation
       collection :operations

--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -123,7 +123,7 @@ module Fog
       request :insert_zone_view
 
       request :list_addresses
-      request :lis_global_address
+      request :list_global_addresses
       request :list_aggregated_addresses
       request :list_aggregated_disk_types
       request :list_aggregated_disks

--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -101,6 +101,7 @@ module Fog
       request :get_zone
       request :get_zone_operation
       request :get_zone_view
+      request :get_ssl_certificate
 
       request :insert_address
       request :insert_global_address

--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -65,6 +65,7 @@ module Fog
       request :delete_url_map
       request :delete_zone_operation
       request :delete_zone_view
+      request :delete_ssl_certificate
 
       request :get_address
       request :get_global_address
@@ -124,6 +125,7 @@ module Fog
       request :insert_target_pool
       request :insert_url_map
       request :insert_zone_view
+      request :insert_ssl_certificate
 
       request :list_addresses
       request :list_aggregated_addresses
@@ -269,6 +271,10 @@ module Fog
 
       model :subnetwork
       collection :subnetworks
+
+      model :ssl_certificate
+      collection :ssl_certificates
+
     end
   end
 end

--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -123,7 +123,6 @@ module Fog
       request :insert_zone_view
 
       request :list_addresses
-      request :list_global_addresses
       request :list_aggregated_addresses
       request :list_aggregated_disk_types
       request :list_aggregated_disks

--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -59,6 +59,7 @@ module Fog
       request :delete_snapshot
       request :delete_subnetwork
       request :delete_target_http_proxy
+      request :delete_target_https_proxy
       request :delete_target_instance
       request :delete_target_pool
       request :delete_url_map
@@ -91,6 +92,7 @@ module Fog
       request :get_snapshot
       request :get_subnetwork
       request :get_target_http_proxy
+      request :get_target_https_proxy
       request :get_target_instance
       request :get_target_pool
       request :get_target_pool_health
@@ -117,6 +119,7 @@ module Fog
       request :insert_snapshot
       request :insert_subnetwork
       request :insert_target_http_proxy
+      request :insert_target_https_proxy
       request :insert_target_instance
       request :insert_target_pool
       request :insert_url_map
@@ -153,6 +156,7 @@ module Fog
       request :list_snapshots
       request :list_subnetworks
       request :list_target_http_proxies
+      request :list_target_https_proxies
       request :list_target_instances
       request :list_target_pools
       request :list_url_maps
@@ -173,6 +177,8 @@ module Fog
       request :set_server_scheduling
       request :set_tags
       request :set_target_http_proxy_url_map
+      request :set_target_https_proxy_url_map
+
 
       request :attach_disk
       request :detach_disk
@@ -242,6 +248,9 @@ module Fog
 
       model :target_http_proxy
       collection :target_http_proxies
+
+      model :target_https_proxy
+      collection :target_https_proxies
 
       model :url_map
       collection :url_maps

--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -276,7 +276,6 @@ module Fog
 
       model :ssl_certificate
       collection :ssl_certificates
-
     end
   end
 end

--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -167,6 +167,7 @@ module Fog
       request :list_zone_view_resources
       request :list_zone_views
       request :list_zones
+      request :list_ssl_certificates
 
       request :remove_instance_group_instances
       request :remove_target_pool_health_checks

--- a/lib/fog/compute/google/models/global_address.rb
+++ b/lib/fog/compute/google/models/global_address.rb
@@ -1,0 +1,89 @@
+module Fog
+  module Compute
+    class Google
+      ##
+      # Represents an Address resource
+      #
+      # @see https://developers.google.com/compute/docs/reference/latest/addresses
+      class GlobalAddress < Fog::Model
+        identity :name
+
+        attribute :kind
+        attribute :id
+        attribute :address
+        attribute :creation_timestamp, :aliases => "creationTimestamp"
+        attribute :description
+        attribute :self_link, :aliases => "selfLink"
+        attribute :status
+        attribute :users
+
+        IN_USE_STATE   = "IN_USE"
+        RESERVED_STATE = "RESERVED"
+
+        def server
+          return nil if !in_use? || users.nil? || users.empty?
+
+          service.servers.get(users.first.split("/")[-1])
+        end
+
+        def server=(server)
+          requires :identity
+          server ? associate(server) : disassociate
+        end
+
+        def save
+          requires :identity
+
+          data = service.insert_global_address(identity, attributes)
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], nil)
+          operation.wait_for { !pending? }
+          reload
+        end
+
+        def destroy(async = true)
+          requires :identity
+
+          data = service.delete_global_address(identity)
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], nil)
+          operation.wait_for { ready? } unless async
+          operation
+        end
+
+        def reload
+          requires :identity
+
+          data = collection.get(identity)
+          merge_attributes(data.attributes)
+          self
+        end
+
+        def in_use?
+          status == IN_USE_STATE
+        end
+
+        private
+
+        def associate(server)
+          nic = server.network_interfaces.first["name"]
+          data = service.add_server_access_config(server.name, server.zone_name, nic, :address => address)
+          Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], data.body["zone"])
+        end
+
+        def disassociate
+          return nil if !in_use? || users.nil? || users.empty?
+
+          # An address can only be associated with one server at a time
+          server = service.servers.get(users.first.split("/")[-1])
+          nic = server.network_interfaces.first["name"]
+          unless server.network_interfaces.first["accessConfigs"].nil? ||
+              server.network_interfaces.first["accessConfigs"].empty?
+            access_config = server.network_interfaces.first["accessConfigs"].first["name"]
+            data = service.delete_server_access_config(server.name, server.zone_name, nic,
+                                                       :access_config => access_config)
+            Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], data.body["zone"])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/models/global_address.rb
+++ b/lib/fog/compute/google/models/global_address.rb
@@ -75,8 +75,7 @@ module Fog
           # An address can only be associated with one server at a time
           server = service.servers.get(users.first.split("/")[-1])
           nic = server.network_interfaces.first["name"]
-          unless server.network_interfaces.first["accessConfigs"].nil? ||
-              server.network_interfaces.first["accessConfigs"].empty?
+          unless server.network_interfaces.first["accessConfigs"].nil? || server.network_interfaces.first["accessConfigs"].empty?
             access_config = server.network_interfaces.first["accessConfigs"].first["name"]
             data = service.delete_server_access_config(server.name, server.zone_name, nic,
                                                        :access_config => access_config)

--- a/lib/fog/compute/google/models/global_address.rb
+++ b/lib/fog/compute/google/models/global_address.rb
@@ -17,8 +17,8 @@ module Fog
         attribute :status
         attribute :users
 
-        IN_USE_STATE   = "IN_USE"
-        RESERVED_STATE = "RESERVED"
+        IN_USE_STATE   = "IN_USE".freeze
+        RESERVED_STATE = "RESERVED".freeze
 
         def server
           return nil if !in_use? || users.nil? || users.empty?

--- a/lib/fog/compute/google/models/global_addresses.rb
+++ b/lib/fog/compute/google/models/global_addresses.rb
@@ -1,87 +1,42 @@
 module Fog
   module Compute
     class Google
-      ##
-      # Represents an Address resource
-      #
-      # @see https://developers.google.com/compute/docs/reference/latest/addresses
-      class Address < Fog::Model
-        identity :name
+      class GlobalAddresses < Fog::Collection
+        model Fog::Compute::Google::GlobalAddress
 
-        attribute :kind
-        attribute :id
-        attribute :address
-        attribute :creation_timestamp, :aliases => "creationTimestamp"
-        attribute :description
-        attribute :self_link, :aliases => "selfLink"
-        attribute :status
-        attribute :users
-
-        IN_USE_STATE   = "IN_USE"
-        RESERVED_STATE = "RESERVED"
-
-        def server
-          return nil if !in_use? || users.nil? || users.empty?
-
-          service.servers.get(users.first.split("/")[-1])
+        def all(filters = {})
+          data = []
+          service.list_aggregated_addresses.body["items"].each_value do |region|
+              data.concat(region["addresses"]) if region["addresses"]
+          load(data)
         end
 
-        def server=(server)
-          requires :identity
-          server ? associate(server) : disassociate
-        end
-
-        def save
-          requires :identity
-
-          data = service.insert_global_address(identity, attributes)
-          operation = Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], nil)
-          operation.wait_for { !pending? }
-          reload
-        end
-
-        def destroy(async = true)
-          requires :identity
-
-          data = service.delete_global_address(identity)
-          operation = Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], nil)
-          operation.wait_for { ready? } unless async
-          operation
-        end
-
-        def reload
-          requires :identity
-
-          data = collection.get(identity)
-          merge_attributes(data.attributes)
-          self
-        end
-
-        def in_use?
-          status == IN_USE_STATE
-        end
-
-        private
-
-        def associate(server)
-          nic = server.network_interfaces.first["name"]
-          data = service.add_server_access_config(server.name, server.zone_name, nic, :address => address)
-          Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], data.body["zone"])
-        end
-
-        def disassociate
-          return nil if !in_use? || users.nil? || users.empty?
-
-          # An address can only be associated with one server at a time
-          server = service.servers.get(users.first.split("/")[-1])
-          nic = server.network_interfaces.first["name"]
-          unless server.network_interfaces.first["accessConfigs"].nil? ||
-              server.network_interfaces.first["accessConfigs"].empty?
-            access_config = server.network_interfaces.first["accessConfigs"].first["name"]
-            data = service.delete_server_access_config(server.name, server.zone_name, nic,
-                                                       :access_config => access_config)
-            Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], data.body["zone"])
+        def get(identity)
+          if address = service.get_global_address(identity).body
+            new(address)
           end
+        rescue Fog::Errors::NotFound
+          nil
+        end
+
+        def get_by_ip_address(ip_address)
+          addresses = service.list_aggregated_addresses(:filter => "address eq .*#{ip_address}").body["items"]
+          address = addresses.each_value.select { |region| region.key?("addresses") }
+
+          return nil if address.empty?
+          new(address.first["addresses"].first)
+        end
+
+        def get_by_name(ip_name)
+          names = service.list_aggregated_addresses(:filter => "name eq .*#{ip_name}").body["items"]
+          name = names.each_value.select { |region| region.key?("addresses") }
+
+          return nil if name.empty?
+          new(name.first["addresses"].first)
+        end
+
+        def get_by_ip_address_or_name(ip_address_or_name)
+          get_by_ip_address(ip_address_or_name) || get_by_name(ip_address_or_name)
         end
       end
     end

--- a/lib/fog/compute/google/models/global_addresses.rb
+++ b/lib/fog/compute/google/models/global_addresses.rb
@@ -4,7 +4,7 @@ module Fog
       class GlobalAddresses < Fog::Collection
         model Fog::Compute::Google::GlobalAddress
 
-        def all(filters = {})
+        def all(_filters = {})
           data = []
           service.list_aggregated_addresses.body["items"].each_value do |region|
               data.concat(region["addresses"]) if region["addresses"]

--- a/lib/fog/compute/google/models/global_addresses.rb
+++ b/lib/fog/compute/google/models/global_addresses.rb
@@ -8,6 +8,7 @@ module Fog
           data = []
           service.list_aggregated_addresses.body["items"].each_value do |region|
               data.concat(region["addresses"]) if region["addresses"]
+          end
           load(data)
         end
 

--- a/lib/fog/compute/google/models/global_addresses.rb
+++ b/lib/fog/compute/google/models/global_addresses.rb
@@ -1,0 +1,89 @@
+module Fog
+  module Compute
+    class Google
+      ##
+      # Represents an Address resource
+      #
+      # @see https://developers.google.com/compute/docs/reference/latest/addresses
+      class Address < Fog::Model
+        identity :name
+
+        attribute :kind
+        attribute :id
+        attribute :address
+        attribute :creation_timestamp, :aliases => "creationTimestamp"
+        attribute :description
+        attribute :self_link, :aliases => "selfLink"
+        attribute :status
+        attribute :users
+
+        IN_USE_STATE   = "IN_USE"
+        RESERVED_STATE = "RESERVED"
+
+        def server
+          return nil if !in_use? || users.nil? || users.empty?
+
+          service.servers.get(users.first.split("/")[-1])
+        end
+
+        def server=(server)
+          requires :identity
+          server ? associate(server) : disassociate
+        end
+
+        def save
+          requires :identity
+
+          data = service.insert_global_address(identity, attributes)
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], nil)
+          operation.wait_for { !pending? }
+          reload
+        end
+
+        def destroy(async = true)
+          requires :identity
+
+          data = service.delete_global_address(identity)
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], nil)
+          operation.wait_for { ready? } unless async
+          operation
+        end
+
+        def reload
+          requires :identity
+
+          data = collection.get(identity)
+          merge_attributes(data.attributes)
+          self
+        end
+
+        def in_use?
+          status == IN_USE_STATE
+        end
+
+        private
+
+        def associate(server)
+          nic = server.network_interfaces.first["name"]
+          data = service.add_server_access_config(server.name, server.zone_name, nic, :address => address)
+          Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], data.body["zone"])
+        end
+
+        def disassociate
+          return nil if !in_use? || users.nil? || users.empty?
+
+          # An address can only be associated with one server at a time
+          server = service.servers.get(users.first.split("/")[-1])
+          nic = server.network_interfaces.first["name"]
+          unless server.network_interfaces.first["accessConfigs"].nil? ||
+              server.network_interfaces.first["accessConfigs"].empty?
+            access_config = server.network_interfaces.first["accessConfigs"].first["name"]
+            data = service.delete_server_access_config(server.name, server.zone_name, nic,
+                                                       :access_config => access_config)
+            Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], data.body["zone"])
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/models/ssl_certificate.rb
+++ b/lib/fog/compute/google/models/ssl_certificate.rb
@@ -5,7 +5,7 @@ module Fog
       # Represents a Subnetwork resource
       #
       # @see https://cloud.google.com/compute/docs/reference/latest/sslCertificates
-      class SSLCertificate < Fog::Model
+      class SslCertificate < Fog::Model
         identity :name
         attribute :id
         attribute :creation_timestamp, :aliases => "creationTimestamp"

--- a/lib/fog/compute/google/models/ssl_certificate.rb
+++ b/lib/fog/compute/google/models/ssl_certificate.rb
@@ -29,7 +29,6 @@ module Fog
           operation.wait_for { ready? } unless async
           operation
         end
-
       end
     end
   end

--- a/lib/fog/compute/google/models/ssl_certificate.rb
+++ b/lib/fog/compute/google/models/ssl_certificate.rb
@@ -1,0 +1,36 @@
+module Fog
+  module Compute
+    class Google
+      ##
+      # Represents a Subnetwork resource
+      #
+      # @see https://cloud.google.com/compute/docs/reference/latest/sslCertificates
+      class SSLCertificate < Fog::Model
+        identity :name
+        attribute :id
+        attribute :creation_timestamp, :aliases => "creationTimestamp"
+        attribute :description
+        attribute :self_link, :aliases => "selfLink"
+        attribute :certificate
+        attribute :private_key, :aliases => "privateKey"
+
+        def save
+          requires :identity, :certificate, :private_key
+          data = service.insert_ssl_certificate(identity, certificate, private_key, attributes)
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], nil)
+          operation.wait_for { !pending? }
+          reload
+        end
+
+        def destroy(async = true)
+          requires :identity
+          data = service.delete_ssl_certificate(identity)
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data.body["name"], nil)
+          operation.wait_for { ready? } unless async
+          operation
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/models/ssl_certificates.rb
+++ b/lib/fog/compute/google/models/ssl_certificates.rb
@@ -4,8 +4,8 @@ module Fog
       class SSLCertificates < Fog::Collection
         model Fog::Compute::Google::SSLCertificate
 
-        def get(identity)
-          if certificate = service.get_ssl_certificate(identity).body
+        def get(certificate_name)
+          if certificate = service.get_ssl_certificate(certificate_name).body
             new(certificate)
           end
         rescue Fog::Errors::NotFound

--- a/lib/fog/compute/google/models/ssl_certificates.rb
+++ b/lib/fog/compute/google/models/ssl_certificates.rb
@@ -1,8 +1,17 @@
 module Fog
   module Compute
     class Google
-      class SSLCerficates < Fog::Collection
+      class SSLCertificates < Fog::Collection
         model Fog::Compute::Google::SSLCertificate
+
+        def get(identity)
+          if certificate = service.get_ssl_certificate(identity).body
+            new(certificate)
+          end
+        rescue Fog::Errors::NotFound
+          nil
+        end
+
       end
     end
   end

--- a/lib/fog/compute/google/models/ssl_certificates.rb
+++ b/lib/fog/compute/google/models/ssl_certificates.rb
@@ -12,6 +12,10 @@ module Fog
           nil
         end
 
+        def all(filters = {})
+          data = service.list_ssl_certificates.body["items"] || []
+          load(data)
+        end
       end
     end
   end

--- a/lib/fog/compute/google/models/ssl_certificates.rb
+++ b/lib/fog/compute/google/models/ssl_certificates.rb
@@ -1,8 +1,8 @@
 module Fog
   module Compute
     class Google
-      class SSLCertificates < Fog::Collection
-        model Fog::Compute::Google::SSLCertificate
+      class SslCertificates < Fog::Collection
+        model Fog::Compute::Google::SslCertificate
 
         def get(certificate_name)
           if certificate = service.get_ssl_certificate(certificate_name).body

--- a/lib/fog/compute/google/models/ssl_certificates.rb
+++ b/lib/fog/compute/google/models/ssl_certificates.rb
@@ -1,0 +1,9 @@
+module Fog
+  module Compute
+    class Google
+      class SSLCerficates < Fog::Collection
+        model Fog::Compute::Google::SSLCertificate
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/models/ssl_certificates.rb
+++ b/lib/fog/compute/google/models/ssl_certificates.rb
@@ -12,7 +12,7 @@ module Fog
           nil
         end
 
-        def all(filters = {})
+        def all(_filters = {})
           data = service.list_ssl_certificates.body["items"] || []
           load(data)
         end

--- a/lib/fog/compute/google/models/target_http_proxy.rb
+++ b/lib/fog/compute/google/models/target_http_proxy.rb
@@ -16,7 +16,7 @@ module Fog
 
           options = {
             "description" => description,
-            "urlMap"      => url_map
+            "urlMap" => url_map
           }
 
           data = service.insert_target_http_proxy(name, options).body
@@ -38,8 +38,8 @@ module Fog
           operation
         end
 
-        def set_url_map(urlMap)
-          operation = service.set_target_http_proxy_url_map(self, urlMap)
+        def set_url_map(url_map)
+          service.set_target_http_proxy_url_map(self, url_map)
           reload
         end
 
@@ -64,7 +64,7 @@ module Fog
           self
         end
 
-        RUNNING_STATE = "READY"
+        RUNNING_STATE = "READY".freeze
       end
     end
   end

--- a/lib/fog/compute/google/models/target_https_proxies.rb
+++ b/lib/fog/compute/google/models/target_https_proxies.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Compute
+    class Google
+      class TargetHttpsProxies < Fog::Collection
+        model Fog::Compute::Google::TargetHttpsProxy
+
+        def all(_filters = {})
+          data = service.list_target_https_proxies.body["items"] || []
+          load(data)
+        end
+
+        def get(identity)
+          if target_https_proxy = service.get_target_https_proxy(identity).body
+            new(target_https_proxy)
+          end
+        rescue Fog::Errors::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/models/target_https_proxy.rb
+++ b/lib/fog/compute/google/models/target_https_proxy.rb
@@ -1,0 +1,71 @@
+module Fog
+  module Compute
+    class Google
+      class TargetHttpsProxy < Fog::Model
+        identity :name
+
+        attribute :kind, :aliases => "kind"
+        attribute :self_link, :aliases => "selfLink"
+        attribute :id, :aliases => "id"
+        attribute :creation_timestamp, :aliases => "creationTimestamp"
+        attribute :description, :aliases => "description"
+        attribute :url_map, :aliases => "urlMap"
+
+        def save
+          requires :name
+
+          options = {
+              "description" => description,
+              "urlMap"      => url_map
+          }
+
+          data = service.insert_target_https_proxy(name, options).body
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data["name"], data["zone"])
+          operation.wait_for { !pending? }
+          reload
+        end
+
+        def destroy(async = true)
+          requires :name
+          operation = service.delete_target_https_proxy(name)
+          unless async
+            # wait until "DONE" to ensure the operation doesn't fail, raises
+            # exception on error
+            Fog.wait_for do
+              operation.body["status"] == "DONE"
+            end
+          end
+          operation
+        end
+
+        def set_url_map(urlMap)
+          operation = service.set_target_https_proxy_url_map(self, urlMap)
+          reload
+        end
+
+        def ready?
+          service.get_target_https_proxy(name)
+          true
+        rescue Fog::Errors::NotFound
+          false
+        end
+
+        def reload
+          requires :name
+
+          return unless data = begin
+            collection.get(name)
+          rescue Excon::Errors::SocketError
+            nil
+          end
+
+          new_attributes = data.attributes
+          merge_attributes(new_attributes)
+          self
+        end
+
+        RUNNING_STATE = "READY"
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/models/target_https_proxy.rb
+++ b/lib/fog/compute/google/models/target_https_proxy.rb
@@ -10,17 +10,19 @@ module Fog
         attribute :creation_timestamp, :aliases => "creationTimestamp"
         attribute :description, :aliases => "description"
         attribute :url_map, :aliases => "urlMap"
+        attribute :ssl_certificates, :aliases => "sslCertificates"
 
         def save
           requires :name
 
           options = {
-              "description" => description,
-              "urlMap"      => url_map
+              "description"     => description,
+              "urlMap"          => url_map,
+              "sslCertificates" => ssl_certificates
           }
 
           data = service.insert_target_https_proxy(name, options).body
-          operation = Fog::Compute::Google::Operations.new(:service => service).get(data["name"], data["zone"])
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data["name"])
           operation.wait_for { !pending? }
           reload
         end

--- a/lib/fog/compute/google/models/target_https_proxy.rb
+++ b/lib/fog/compute/google/models/target_https_proxy.rb
@@ -66,7 +66,7 @@ module Fog
           self
         end
 
-        RUNNING_STATE = "READY"
+        RUNNING_STATE = "READY".freeze
       end
     end
   end

--- a/lib/fog/compute/google/models/target_https_proxy.rb
+++ b/lib/fog/compute/google/models/target_https_proxy.rb
@@ -16,9 +16,9 @@ module Fog
           requires :name
 
           options = {
-              "description"     => description,
-              "urlMap"          => url_map,
-              "sslCertificates" => ssl_certificates
+            "description" => description,
+            "urlMap" => url_map,
+            "sslCertificates" => ssl_certificates
           }
 
           data = service.insert_target_https_proxy(name, options).body
@@ -40,8 +40,8 @@ module Fog
           operation
         end
 
-        def set_url_map(urlMap)
-          operation = service.set_target_https_proxy_url_map(self, urlMap)
+        def set_url_map(url_map)
+          service.set_target_https_proxy_url_map(self, url_map)
           reload
         end
 

--- a/lib/fog/compute/google/requests/delete_global_address.rb
+++ b/lib/fog/compute/google/requests/delete_global_address.rb
@@ -11,8 +11,8 @@ module Fog
         def delete_global_address(address_name)
           api_method = @compute.global_addresses.delete
           parameters = {
-              "project" => @project,
-              "address" => address_name,
+            "project" => @project,
+            "address" => address_name,
           }
           request(api_method, parameters)
         end

--- a/lib/fog/compute/google/requests/delete_global_address.rb
+++ b/lib/fog/compute/google/requests/delete_global_address.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def delete_global_address(_address_name)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def delete_global_address(address_name)
+          api_method = @compute.global_addresses.delete
+          parameters = {
+              "project" => @project,
+              "address" => address_name,
+          }
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/delete_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/delete_ssl_certificate.rb
@@ -11,8 +11,8 @@ module Fog
         def delete_ssl_certificate(certificate_name)
           api_method = @compute.ssl_certificates.delete
           parameters = {
-            'project'=> @project,
-            'sslCertificate'  => certificate_name
+            "project"  => @project,
+            "sslCertificate"  => certificate_name
           }
 
           request(api_method, parameters)

--- a/lib/fog/compute/google/requests/delete_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/delete_ssl_certificate.rb
@@ -10,7 +10,7 @@ module Fog
       class Real
         def delete_ssl_certificate(certificate_name)
 
-          api_method = @compute.ssl_certificate.delete
+          api_method = @compute.ssl_certificates.delete
           parameters = {
             "project"    => @project,
             "sslCertificate"     => certificate_name

--- a/lib/fog/compute/google/requests/delete_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/delete_ssl_certificate.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def delete_ssl_certificate(certificate_name)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def delete_ssl_certificate(certificate_name)
+
+          api_method = @compute.ssl_certificate.delete
+          parameters = {
+            "project"    => @project,
+            "sslCertificate"     => certificate_name
+          }
+
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/delete_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/delete_ssl_certificate.rb
@@ -2,18 +2,17 @@ module Fog
   module Compute
     class Google
       class Mock
-        def delete_ssl_certificate(certificate_name)
+        def delete_ssl_certificate(_certificate_name)
           Fog::Mock.not_implemented
         end
       end
 
       class Real
         def delete_ssl_certificate(certificate_name)
-
           api_method = @compute.ssl_certificates.delete
           parameters = {
-            "project"    => @project,
-            "sslCertificate"     => certificate_name
+            'project'=> @project,
+            'sslCertificate'  => certificate_name
           }
 
           request(api_method, parameters)

--- a/lib/fog/compute/google/requests/delete_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/delete_ssl_certificate.rb
@@ -11,8 +11,8 @@ module Fog
         def delete_ssl_certificate(certificate_name)
           api_method = @compute.ssl_certificates.delete
           parameters = {
-            "project"  => @project,
-            "sslCertificate"  => certificate_name
+            "project" => @project,
+            "sslCertificate" => certificate_name
           }
 
           request(api_method, parameters)

--- a/lib/fog/compute/google/requests/delete_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/delete_target_https_proxy.rb
@@ -2,7 +2,7 @@ module Fog
   module Compute
     class Google
       class Mock
-        def delete_target_https_proxy(name)
+        def delete_target_https_proxy(_name)
           Fog::Mock.not_implemented
         end
       end
@@ -11,8 +11,8 @@ module Fog
         def delete_target_https_proxy(name)
           api_method = @compute.target_https_proxies.delete
           parameters = {
-            "project" => @project,
-            "targetHttpsProxy" => name
+            'project' => @project,
+            'targetHttpsProxy' => name
           }
 
           request(api_method, parameters)

--- a/lib/fog/compute/google/requests/delete_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/delete_target_https_proxy.rb
@@ -1,0 +1,23 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def delete_target_https_proxy(name)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def delete_target_https_proxy(name)
+          api_method = @compute.target_https_proxies.delete
+          parameters = {
+            "project" => @project,
+            "targetHttpsProxy" => name
+          }
+
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/delete_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/delete_target_https_proxy.rb
@@ -11,8 +11,8 @@ module Fog
         def delete_target_https_proxy(name)
           api_method = @compute.target_https_proxies.delete
           parameters = {
-            'project' => @project,
-            'targetHttpsProxy' => name
+            "project" => @project,
+            "targetHttpsProxy" => name
           }
 
           request(api_method, parameters)

--- a/lib/fog/compute/google/requests/get_global_address.rb
+++ b/lib/fog/compute/google/requests/get_global_address.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def get_global_address(_address_name)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def get_global_address(address_name)
+          api_method = @compute.global_addresses.get
+          parameters = {
+              "project" => @project,
+              "address" => address_name
+          }
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/get_global_address.rb
+++ b/lib/fog/compute/google/requests/get_global_address.rb
@@ -11,8 +11,8 @@ module Fog
         def get_global_address(address_name)
           api_method = @compute.global_addresses.get
           parameters = {
-            'project' => @project,
-            'address' => address_name
+            "project" => @project,
+            "address" => address_name
           }
           request(api_method, parameters)
         end

--- a/lib/fog/compute/google/requests/get_global_address.rb
+++ b/lib/fog/compute/google/requests/get_global_address.rb
@@ -11,8 +11,8 @@ module Fog
         def get_global_address(address_name)
           api_method = @compute.global_addresses.get
           parameters = {
-              "project" => @project,
-              "address" => address_name
+            'project' => @project,
+            'address' => address_name
           }
           request(api_method, parameters)
         end

--- a/lib/fog/compute/google/requests/get_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/get_ssl_certificate.rb
@@ -9,7 +9,7 @@ module Fog
 
       class Real
         def get_ssl_certificate(certificate_name)
-          api_method = @compute.ssl_certificate.get
+          api_method = @compute.ssl_certificates.get
           parameters = {
             "project" => @project,
             "sslCertificate" => certificate_name

--- a/lib/fog/compute/google/requests/get_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/get_ssl_certificate.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def get_ssl_certificate(_certificate_name)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def get_ssl_certificate(certificate_name)
+          api_method = @compute.ssl_certificate.get
+          parameters = {
+            "project" => @project,
+            "sslCertificate" => certificate_name
+          }
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/get_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/get_target_https_proxy.rb
@@ -2,7 +2,7 @@ module Fog
   module Compute
     class Google
       class Mock
-        def get_target_https_proxy(name)
+        def get_target_https_proxy(_name)
           Fog::Mock.not_implemented
         end
       end
@@ -11,8 +11,8 @@ module Fog
         def get_target_https_proxy(name)
           api_method = @compute.target_https_proxies.get
           parameters = {
-            "project" => @project,
-            "targetHttpsProxy" => name
+            'project' => @project,
+            'targetHttpsProxy' => name
           }
 
           request(api_method, parameters)

--- a/lib/fog/compute/google/requests/get_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/get_target_https_proxy.rb
@@ -1,0 +1,23 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def get_target_https_proxy(name)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def get_target_https_proxy(name)
+          api_method = @compute.target_https_proxies.get
+          parameters = {
+            "project" => @project,
+            "targetHttpsProxy" => name
+          }
+
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/get_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/get_target_https_proxy.rb
@@ -11,8 +11,8 @@ module Fog
         def get_target_https_proxy(name)
           api_method = @compute.target_https_proxies.get
           parameters = {
-            'project' => @project,
-            'targetHttpsProxy' => name
+            "project" => @project,
+            "targetHttpsProxy" => name
           }
 
           request(api_method, parameters)

--- a/lib/fog/compute/google/requests/insert_global_address.rb
+++ b/lib/fog/compute/google/requests/insert_global_address.rb
@@ -11,7 +11,7 @@ module Fog
         def insert_global_address(address_name, options = {})
           api_method = @compute.global_addresses.insert
           parameters = {
-              "project" => @project
+            "project" => @project
           }
           body_object = { "name" => address_name }
           body_object["description"] = options[:description] if options[:description]

--- a/lib/fog/compute/google/requests/insert_global_address.rb
+++ b/lib/fog/compute/google/requests/insert_global_address.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def insert_global_address(_address_name, _options = {})
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def insert_global_address(address_name, options = {})
+          api_method = @compute.global_addresses.insert
+          parameters = {
+              "project" => @project
+          }
+          body_object = { "name" => address_name }
+          body_object["description"] = options[:description] if options[:description]
+
+          request(api_method, parameters, body_object)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/insert_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/insert_ssl_certificate.rb
@@ -2,25 +2,24 @@ module Fog
   module Compute
     class Google
       class Mock
-        def insert_ssl_certificate(certificate_name, certificate, private_key,_options = {})
+        def insert_ssl_certificate(_certificate_name, _certificate, _private_key, _options = {})
           Fog::Mock.not_implemented
         end
       end
 
       class Real
         def insert_ssl_certificate(certificate_name, certificate, private_key, options = {})
-
           api_method = @compute.ssl_certificates.insert
           parameters = {
-            "project" => @project
+            'project' => @project
           }
           body_object = {
-            "certificate" => certificate,
-            "name"        => certificate_name,
-            "privateKey"     => private_key
+            'certificate' => certificate,
+            'name'        => certificate_name,
+            'privateKey'  => private_key
           }
 
-          body_object["description"] = options[:description] if options[:description]
+          body_object['description'] = options[:description] if options[:description]
 
           request(api_method, parameters, body_object)
         end

--- a/lib/fog/compute/google/requests/insert_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/insert_ssl_certificate.rb
@@ -10,7 +10,7 @@ module Fog
       class Real
         def insert_ssl_certificate(certificate_name, certificate, private_key, options = {})
 
-          api_method = @compute.ssl_certificate.insert
+          api_method = @compute.ssl_certificates.insert
           parameters = {
             "project" => @project
           }

--- a/lib/fog/compute/google/requests/insert_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/insert_ssl_certificate.rb
@@ -11,15 +11,15 @@ module Fog
         def insert_ssl_certificate(certificate_name, certificate, private_key, options = {})
           api_method = @compute.ssl_certificates.insert
           parameters = {
-            'project' => @project
+            "project" => @project
           }
           body_object = {
-            'certificate' => certificate,
-            'name'        => certificate_name,
-            'privateKey'  => private_key
+            "certificate" => certificate,
+            "name" => certificate_name,
+            "privateKey" => private_key
           }
 
-          body_object['description'] = options[:description] if options[:description]
+          body_object["description"] = options[:description] if options[:description]
 
           request(api_method, parameters, body_object)
         end

--- a/lib/fog/compute/google/requests/insert_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/insert_ssl_certificate.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def insert_ssl_certificate(certificate_name, certificate, private_key,_options = {})
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def insert_ssl_certificate(certificate_name, certificate, private_key, options = {})
+
+          api_method = @compute.ssl_certificate.insert
+          parameters = {
+            "project" => @project
+          }
+          body_object = {
+            "certificate" => certificate,
+            "name"        => certificate_name,
+            "privateKey"     => private_key
+          }
+
+          body_object["description"] = options[:description] if options[:description]
+
+          request(api_method, parameters, body_object)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/insert_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/insert_target_https_proxy.rb
@@ -2,7 +2,7 @@ module Fog
   module Compute
     class Google
       class Mock
-        def insert_target_https_proxy(name, options = {})
+        def insert_target_https_proxy(_name, _options = {})
           Fog::Mock.not_implemented
         end
       end

--- a/lib/fog/compute/google/requests/insert_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/insert_target_https_proxy.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def insert_target_https_proxy(name, options = {})
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def insert_target_https_proxy(name, opts = {})
+          api_method = @compute.target_https_proxies.insert
+          parameters = {
+            "project" => @project
+          }
+          body_object = { "name" => name }
+          body_object.merge!(opts)
+
+          request(api_method, parameters, body_object)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/list_ssl_certificates.rb
+++ b/lib/fog/compute/google/requests/list_ssl_certificates.rb
@@ -2,13 +2,13 @@ module Fog
   module Compute
     class Google
       class Mock
-        def list_ssl_certificates()
+        def list_ssl_certificates
           Fog::Mock.not_implemented
         end
       end
 
       class Real
-        def list_ssl_certificates()
+        def list_ssl_certificates
           api_method = @compute.ssl_certificates.list
           parameters = {
             "project" => @project

--- a/lib/fog/compute/google/requests/list_ssl_certificates.rb
+++ b/lib/fog/compute/google/requests/list_ssl_certificates.rb
@@ -1,0 +1,21 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def list_ssl_certificates()
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def list_ssl_certificates()
+          api_method = @compute.ssl_certificates.list
+          parameters = {
+            "project" => @project
+          }
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/list_target_https_proxies.rb
+++ b/lib/fog/compute/google/requests/list_target_https_proxies.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def list_target_https_proxies
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def list_target_https_proxies
+          api_method = @compute.target_https_proxies.list
+          parameters = {
+            "project" => @project
+          }
+
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/compute/google/requests/set_target_https_proxy_url_map.rb
+++ b/lib/fog/compute/google/requests/set_target_https_proxy_url_map.rb
@@ -19,7 +19,7 @@ module Fog
             "urlMap" => url_map
           }
 
-          request(api_method, parameters, body_object = body)
+          request(api_method, parameters, body)
         end
       end
     end

--- a/lib/fog/compute/google/requests/set_target_https_proxy_url_map.rb
+++ b/lib/fog/compute/google/requests/set_target_https_proxy_url_map.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def set_target_https_proxy_url_map(_target_https_proxy, _url_map)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def set_target_https_proxy_url_map(target_https_proxy, url_map)
+          api_method = @compute.target_https_proxies.set_url_map
+          parameters = {
+            "project" => @project,
+            "targetHttpsProxy" => target_https_proxy.name
+          }
+          url_map = url_map.self_link unless url_map.class == String
+          body = {
+            "urlMap" => url_map
+          }
+
+          request(api_method, parameters, body_object = body)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Those features are needed if you want to deploy an HTTP(S) load balancer with Fog and want to use SSL termination.