### PR TITLE
Revert "Test commit please ignore"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 The main maintainers for the Google sections are @icco, @Temikus and @plribeiro3000. Please send pull requests to them.
 
-**Note: This is a testing note**
-
 **As of v0.1.1, Google no longer supports Ruby versions less than 2.0.0.**
 
 **Currently, `fog-google` does not support versions of `google-api-client` >= 0.9 or <= 0.8.5.**


### PR DESCRIPTION
This reverts commit 8957f5bd206dd95ef1eedbb5543a1f1e99bd4868.

This is an (admittedly) embarassing mistake of mine when showing git
workflow to a colleague. Apologies for the hassle and let me know
if you'd like to rebase. 

However, I felt uneasy doing a rebase and
force push on a large public repo.

@icco