### PR TITLE
Upgrade google client instance groups

### DIFF
--- a/lib/fog/compute/google/models/instance_group.rb
+++ b/lib/fog/compute/google/models/instance_group.rb
@@ -53,10 +53,10 @@ module Fog
           requires :identity, :zone
 
           instance_list = []
-          data = service.list_instance_group_instances(identity, zone_name).body
-          if data["items"]
-            data["items"].each do |instance|
-              instance_list << service.servers.get(instance["instance"].split("/")[-1], zone_name)
+          data = service.list_instance_group_instances(identity, zone_name)
+          if data.items
+            data.items.each do |instance|
+              instance_list << service.servers.get(instance.instance.split("/")[-1], zone_name)
             end
           end
           instance_list

--- a/lib/fog/compute/google/models/instance_groups.rb
+++ b/lib/fog/compute/google/models/instance_groups.rb
@@ -19,14 +19,15 @@ module Fog
 
         def get(identity, zone = nil)
           if zone.nil?
-            zones = service.list_aggregated_instance_groups(:filter => "name eq .*#{identity}").body["items"]
-            target_zone = zones.each_value.select { |zone| zone.key?("instanceGroups") }
-            response = target_zone.first["instanceGroups"].first unless target_zone.empty?
-            zone = response["zone"].split("/")[-1]
+            zones = service.list_aggregated_instance_groups(:filter => "name eq .*#{identity}").items
+            instance_groups = zones.each_value.map(&:instance_groups).compact.first
+            if instance_groups
+              zone = instance_groups.first.zone.split("/")[-1]
+            end
           end
 
-          if instance_group = service.get_instance_group(identity, zone).body
-            new(instance_group)
+          if instance_group = service.get_instance_group(identity, zone)
+            new(instance_group.to_h)
           end
         rescue Fog::Errors::NotFound
           nil

--- a/lib/fog/compute/google/models/instance_groups.rb
+++ b/lib/fog/compute/google/models/instance_groups.rb
@@ -6,7 +6,7 @@ module Fog
 
         def all(filters = {})
           if filters[:zone]
-            data = service.list_instance_groups(filters[:zone]).body
+            data = Array(service.list_instance_groups(filters[:zone]))
           else
             data = []
             service.list_aggregated_instance_groups.body["items"].each_value do |group|
@@ -14,7 +14,7 @@ module Fog
             end
           end
 
-          load(data)
+          load(data.map(&:to_h))
         end
 
         def get(identity, zone = nil)

--- a/lib/fog/compute/google/models/instance_groups.rb
+++ b/lib/fog/compute/google/models/instance_groups.rb
@@ -9,8 +9,8 @@ module Fog
             data = Array(service.list_instance_groups(filters[:zone]))
           else
             data = []
-            service.list_aggregated_instance_groups.body["items"].each_value do |group|
-              data.concat(group["instanceGroups"]) if group["instanceGroups"]
+            service.list_aggregated_instance_groups.items.each_value do |group|
+              data.concat(group.instance_groups) if group.instance_groups
             end
           end
 

--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -19,7 +19,7 @@ module Fog
         def get(identity, zone = nil)
           response = nil
           if zone
-            response = service.get_server(identity, zone).body
+            response = service.get_server(identity, zone)
           else
             servers = service.list_aggregated_servers(:filter => "name eq .*#{identity}").body["items"]
             server = servers.each_value.select { |zone| zone.key?("instances") }
@@ -28,7 +28,7 @@ module Fog
             response = server.first["instances"].first unless server.empty?
           end
           return nil if response.nil?
-          new(response)
+          new(response.to_h)
         rescue Fog::Errors::NotFound
           nil
         end

--- a/lib/fog/compute/google/requests/add_instance_group_instances.rb
+++ b/lib/fog/compute/google/requests/add_instance_group_instances.rb
@@ -9,27 +9,26 @@ module Fog
 
       class Real
         def add_instance_group_instances(group_name, zone, instances)
-          api_method = @compute.instance_groups.add_instances
-
-          parameters = {
-            "project" => @project,
-            "instanceGroup" => group_name,
-            "zone" => zone
-          }
-
           instances.map! do |instance|
             if instance.start_with?("https:")
-              { "instance" => instance }
+              ::Google::Apis::ComputeV1::InstanceReference.new(:instance => instance)
             else
-              { "instance" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones/#{zone}/instances/#{instance}\n" }
+              ::Google::Apis::ComputeV1::InstanceReference.new(
+                :instance => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones/#{zone}/instances/#{instance}\n"
+              )
             end
           end
 
-          body_object = {
-            "instances" => instances
-          }
 
-          request(api_method, parameters, body_object)
+          request = ::Google::Apis::ComputeV1::InstanceGroupsAddInstancesRequest.new(
+            :instances => instances
+          )
+          @compute.add_instance_group_instances(
+            @project,
+            zone,
+            group_name,
+            request
+          )
         end
       end
     end

--- a/lib/fog/compute/google/requests/delete_instance_group.rb
+++ b/lib/fog/compute/google/requests/delete_instance_group.rb
@@ -9,14 +9,7 @@ module Fog
 
       class Real
         def delete_instance_group(group_name, zone)
-          api_method = @compute.instance_groups.delete
-          parameters = {
-            "instanceGroup" => group_name,
-            "project" => @project,
-            "zone" => zone
-          }
-
-          request(api_method, parameters)
+          @compute.delete_instance_group(@project, zone, group_name)
         end
       end
     end

--- a/lib/fog/compute/google/requests/get_instance_group.rb
+++ b/lib/fog/compute/google/requests/get_instance_group.rb
@@ -9,14 +9,7 @@ module Fog
 
       class Real
         def get_instance_group(group_name, zone, project = @project)
-          api_method = @compute.instance_groups.get
-          parameters = {
-            "instanceGroup" => group_name,
-            "project" => project,
-            "zone" => zone
-          }
-
-          request(api_method, parameters)
+          @compute.get_instance_group(project, zone, group_name)
         end
       end
     end

--- a/lib/fog/compute/google/requests/get_server.rb
+++ b/lib/fog/compute/google/requests/get_server.rb
@@ -56,14 +56,7 @@ module Fog
             zone = zone_name
           end
 
-          api_method = @compute.instances.get
-          parameters = {
-            "project" => @project,
-            "zone" => zone,
-            "instance" => server_name
-          }
-
-          request(api_method, parameters)
+          @compute.get_instance(@project, zone, server_name)
         end
       end
     end

--- a/lib/fog/compute/google/requests/insert_instance_group.rb
+++ b/lib/fog/compute/google/requests/insert_instance_group.rb
@@ -9,28 +9,25 @@ module Fog
 
       class Real
         def insert_instance_group(group_name, zone, options = {})
-          api_method = @compute.instance_groups.insert
-          parameters = {
-            "project" => @project,
-            "zone" => zone
-          }
+          network_name = if options["network"]
+                           last_url_segment(options["network"])
+                         else
+                           GOOGLE_COMPUTE_DEFAULT_NETWORK
+                         end
 
-          id = Fog::Mock.random_numbers(19).to_s
+          instance_group = ::Google::Apis::ComputeV1::InstanceGroup.new(
+            :description => options["description"],
+            :name => group_name,
+            :network => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/global/networks/#{network_name}",
+          )
 
-          body = {
-            "name" => group_name
-          }
+          @compute.insert_instance_group(@project,
+                                         last_url_segment(zone),
+                                         instance_group)
+        end
 
-          body["description"] = options["description"] if options["description"]
-          network_name = options["network"] ? options["network"].split("/")[-1] : GOOGLE_COMPUTE_DEFAULT_NETWORK
-          body["network"] = "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/global/networks/#{network_name}"
-
-          unless options["subnetwork"].nil?
-            subnetwork_name = options["subnetwork"].split("/")[-1]
-            body["subnetwork"] = "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/regions/#{@region}/subnetworks/#{subnetwork_name}"
-          end
-
-          request(api_method, parameters, body)
+        def last_url_segment(network)
+          network.split("/")[-1]
         end
       end
     end

--- a/lib/fog/compute/google/requests/insert_instance_group.rb
+++ b/lib/fog/compute/google/requests/insert_instance_group.rb
@@ -9,11 +9,11 @@ module Fog
 
       class Real
         def insert_instance_group(group_name, zone, options = {})
-          network_name = if options["network"]
-                           last_url_segment(options["network"])
-                         else
-                           GOOGLE_COMPUTE_DEFAULT_NETWORK
-                         end
+          if options["network"]
+            network_name = last_url_segment(options["network"])
+          else
+            network_name = GOOGLE_COMPUTE_DEFAULT_NETWORK
+          end
 
           instance_group = ::Google::Apis::ComputeV1::InstanceGroup.new(
             :description => options["description"],

--- a/lib/fog/compute/google/requests/list_aggregated_instance_groups.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_instance_groups.rb
@@ -9,13 +9,8 @@ module Fog
 
       class Real
         def list_aggregated_instance_groups(options = {})
-          api_method = @compute.instance_groups.aggregated_list
-          parameters = {
-            "project" => @project
-          }
-          parameters["filter"] = options[:filter] if options[:filter]
-
-          request(api_method, parameters)
+          @compute.list_aggregated_instance_groups(@project,
+                                                   :filter => options[:filter])
         end
       end
     end

--- a/lib/fog/compute/google/requests/list_instance_group_instances.rb
+++ b/lib/fog/compute/google/requests/list_instance_group_instances.rb
@@ -9,14 +9,9 @@ module Fog
 
       class Real
         def list_instance_group_instances(group_name, zone)
-          api_method = @compute.instance_groups.list_instances
-          parameters = {
-            "instanceGroup" => group_name,
-            "project" => @project,
-            "zone" => zone
-          }
-
-          request(api_method, parameters)
+          @compute.list_instance_group_instances(@project,
+                                                 zone,
+                                                 group_name)
         end
       end
     end

--- a/lib/fog/compute/google/requests/list_instance_groups.rb
+++ b/lib/fog/compute/google/requests/list_instance_groups.rb
@@ -9,13 +9,7 @@ module Fog
 
       class Real
         def list_instance_groups(zone)
-          api_method = @compute.instance_groups.list
-          parameters = {
-            "project" => @project,
-            "zone" => zone
-          }
-
-          request(api_method, parameters)
+          @compute.list_instance_groups(@project, zone)
         end
       end
     end

--- a/lib/fog/compute/google/requests/remove_instance_group_instances.rb
+++ b/lib/fog/compute/google/requests/remove_instance_group_instances.rb
@@ -26,7 +26,7 @@ module Fog
             @project,
             zone,
             group_name,
-            request 
+            request
           )
         end
       end

--- a/lib/fog/compute/google/requests/remove_instance_group_instances.rb
+++ b/lib/fog/compute/google/requests/remove_instance_group_instances.rb
@@ -9,27 +9,25 @@ module Fog
 
       class Real
         def remove_instance_group_instances(group_name, zone, instances)
-          api_method = @compute.instance_groups.remove_instances
-
-          parameters = {
-            "project" => @project,
-            "instanceGroup" => group_name,
-            "zone" => zone
-          }
-
           instances.map! do |instance|
             if instance.start_with?("https:")
-              { "instance" => instance }
+              ::Google::Apis::ComputeV1::InstanceReference.new(:instance => instance)
             else
-              { "instance" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones/#{zone}/instances/#{instance}\n" }
+              ::Google::Apis::ComputeV1::InstanceReference.new(
+                :instance => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones/#{zone}/instances/#{instance}\n"
+              )
             end
           end
 
-          body_object = {
-            "instances" => instances
-          }
-
-          request(api_method, parameters, body_object)
+          request = ::Google::Apis::ComputeV1::InstanceGroupsRemoveInstancesRequest.new(
+            :instances => instances
+          )
+          @compute.remove_instance_group_instances(
+            @project,
+            zone,
+            group_name,
+            request 
+          )
         end
       end
     end


### PR DESCRIPTION
A few questions/things I'm not sure of:

1) I haven't reimplemented the deprecated methods here https://github.com/fog/fog-google/blob/master/lib/fog/compute/google/models/instance_groups.rb#L35-L51 - should I? FWIW I'm not sure they even work, e.g. `unless params[:instance] == Array` is missing one `=` to make sense :)
2) `InstanceGroup#save` throws `alreadyExists` error - is that normal? I can change the name and attempt to save it, but then it fails on `subnetwork` as that's apparently ready-only.