### PR TITLE
method :flatMap not resolved

### DIFF
--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -202,8 +202,8 @@ module Fog
 
         def public_ip_addresses
           addresses = []
-          if network_interfaces.respond_to? :flatMap
-            addresses = network_interfaces.flatMap do |nic|
+          if network_interfaces.respond_to? :flat_map
+            addresses = network_interfaces.flat_map do |nic|
               if nic[:access_configs].respond_to? :each
                 nic[:access_configs].select { |config| config[:name] == "External NAT" }
                                     .map { |config| config[:nat_ip] }


### PR DESCRIPTION
as method is not resolved, no server has external IP returned. 
Probably intended method was:  http://ruby-doc.org/core-2.0.0/Enumerable.html#method-i-flat_map
 
as workaround, until this is merged and released users can use alias_method:

```
module Enumerable
  alias_method :flatMap, :flat_map
end
```
