### PR TITLE
Fix file uploading when using Paperclip

### DIFF
--- a/lib/fog/storage/google_json/requests/put_object.rb
+++ b/lib/fog/storage/google_json/requests/put_object.rb
@@ -52,10 +52,13 @@ module Fog
               options[:content_type] = "text/plain"
             elsif data.is_a?(::File)
               options[:content_type] = Fog::Storage.parse_data(data)[:headers]["Content-Type"]
-            elsif data.respond_to?(:content_type) && data.respond_to?(:path)
-              options[:content_type] = data.content_type
-              data = data.path
             end
+          end
+
+          # Paperclip::AbstractAdapter
+          if data.respond_to?(:content_type) && data.respond_to?(:path)
+            options[:content_type] = data.content_type
+            data = data.path
           end
 
           object_config = ::Google::Apis::StorageV1::Object.new(

--- a/lib/fog/storage/google_json/requests/put_object.rb
+++ b/lib/fog/storage/google_json/requests/put_object.rb
@@ -57,7 +57,7 @@ module Fog
 
           # Paperclip::AbstractAdapter
           if data.respond_to?(:content_type) && data.respond_to?(:path)
-            options[:content_type] = data.content_type
+            options[:content_type] ||= data.content_type
             data = data.path
           end
 

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -37,6 +37,18 @@ class TestStorageRequests < StorageShared
     assert_equal("image/png", object[:content_type])
   end
 
+  def test_put_object_contradictory_content_type
+    object_name = new_object_name
+    file = OpenStruct.new(:path => some_temp_file,
+                          :content_type => "text/plain")
+    @client.put_object(some_bucket_name, object_name, file, :content_type => "image/png")
+
+    object = @client.get_object(some_bucket_name, object_name)
+
+    assert_equal(object_name, object[:name])
+    assert_equal("image/png", object[:content_type])
+  end
+
   def test_put_object_predefined_acl
     @client.put_object(some_bucket_name, new_object_name, some_temp_file,
                        :predefined_acl => "publicRead")

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -29,7 +29,7 @@ class TestStorageRequests < StorageShared
     object_name = new_object_name
     paperclip_file = OpenStruct.new(:path => some_temp_file,
                                     :content_type => "image/png")
-    @client.put_object(some_bucket_name, object_name, paperclip_file)
+    @client.put_object(some_bucket_name, object_name, paperclip_file, :content_type => "image/png")
 
     object = @client.get_object(some_bucket_name, object_name)
 


### PR DESCRIPTION
[Paperclip](https://github.com/thoughtbot/paperclip) passes `:content_type` to fog which caused fog-google not to use the data’s path (and therefore causing a `Google::Apis::ClientError`). See #289 for more information.