### PR TITLE
Remove call to nonexistent function

### DIFF
--- a/lib/fog/compute/google/models/disk.rb
+++ b/lib/fog/compute/google/models/disk.rb
@@ -67,7 +67,14 @@ module Fog
         end
 
         def get_as_boot_disk(writable = true, auto_delete = false)
-          get_object(writable, true, nil, auto_delete)
+          mode = writable ? "READ_WRITE" : "READ_ONLY"
+          {
+            autoDelete: auto_delete,
+            boot: true,
+            source: self_link,
+            mode: mode,
+            type: "PERSISTENT"
+          }
         end
 
         def ready?

--- a/lib/fog/compute/google/models/disk.rb
+++ b/lib/fog/compute/google/models/disk.rb
@@ -67,13 +67,12 @@ module Fog
         end
 
         def get_as_boot_disk(writable = true, auto_delete = false)
-          mode = writable ? "READ_WRITE" : "READ_ONLY"
           {
-            autoDelete: auto_delete,
-            boot: true,
-            source: self_link,
-            mode: mode,
-            type: "PERSISTENT"
+            :autoDelete => auto_delete,
+            :boot => true,
+            :source => self_link,
+            :mode =>  writable ? "READ_WRITE" : "READ_ONLY",
+            :type => "PERSISTENT"
           }
         end
 


### PR DESCRIPTION
At some point we deleted this function: https://github.com/fog/fog-google/blame/v0.5.0/lib/fog/compute/google/models/disk.rb#L59-L70, which caused https://github.com/fog/fog-google/issues/300. This is a fix, altho I'm not entirely sure if we should even have `get_as_boot_disk` anymore.