### PR TITLE
Fix setting service accounts and scopes on GCE instances

### DIFF
--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -426,7 +426,7 @@ module Fog
           options = attributes.reject { |_, v| v.nil? }
 
           if service_accounts && service_accounts[0]
-            service_accounts[0].merge!(:scopes => map_scopes(service_accounts[0][:scopes]))
+            service_accounts[0][:scopes] = map_scopes(service_accounts[0][:scopes])
             options[:service_accounts] = service_accounts
           end
 

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -425,10 +425,9 @@ module Fog
 
           options = attributes.reject { |_, v| v.nil? }
 
-          if service_accounts && service_accounts[:scopes]
-            options[:service_accounts] = service_accounts.merge(
-              :scopes => map_scopes(service_accounts[:scopes])
-            )
+          if service_accounts && service_accounts[0]
+            service_accounts[0].merge!(:scopes => map_scopes(service_accounts[0][:scopes]))
+            options[:service_accounts] = service_accounts
           end
 
           if attributes[:external_ip]


### PR DESCRIPTION
Setting service accounts should use an array of hashes instead
of a hash. See the resource.serviceAccounts[] field in the below
Google API document for details.

https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert