### PR TITLE
Fix deprecation messages raising ArgumentError

### DIFF
--- a/lib/fog/storage/google_json/requests/get_object_url.rb
+++ b/lib/fog/storage/google_json/requests/get_object_url.rb
@@ -5,14 +5,14 @@ module Fog
         # Get an expiring object url from GCS
         # Deprecated, redirects to get_object_https_url.rb
         def get_object_url(bucket_name, object_name, expires)
-          Fog::Logger.deprecation("Fog::Storage::Google => ##{get_object_url} is deprecated, use ##{get_object_https_url} instead[/] [light_black](#{caller(0..0)})")
+          Fog::Logger.deprecation("Fog::Storage::Google => #get_object_url is deprecated, use #get_object_https_url instead[/] [light_black](#{caller(0..0)})")
           get_object_https_url(bucket_name, object_name, expires)
         end
       end
 
       class Mock # :nodoc:all
         def get_object_url(bucket_name, object_name, expires)
-          Fog::Logger.deprecation("Fog::Storage::Google => ##{get_object_url} is deprecated, use ##{get_object_https_url} instead[/] [light_black](#{caller(0..0)})")
+          Fog::Logger.deprecation("Fog::Storage::Google => #get_object_url is deprecated, use #get_object_https_url instead[/] [light_black](#{caller(0..0)})")
           get_object_https_url(bucket_name, object_name, expires)
         end
       end

--- a/lib/fog/storage/google_xml/requests/get_object_url.rb
+++ b/lib/fog/storage/google_xml/requests/get_object_url.rb
@@ -14,14 +14,14 @@ module Fog
         #   * body<~String> - url for object
 
         def get_object_url(bucket_name, object_name, expires)
-          Fog::Logger.deprecation("Fog::Storage::Google => ##{get_object_url} is deprecated, use ##{get_object_https_url} instead[/] [light_black](#{caller.first})")
+          Fog::Logger.deprecation("Fog::Storage::Google => #get_object_url is deprecated, use #get_object_https_url instead[/] [light_black](#{caller(1..1).first})")
           get_object_https_url(bucket_name, object_name, expires)
         end
       end
 
       class Mock # :nodoc:all
         def get_object_url(bucket_name, object_name, expires)
-          Fog::Logger.deprecation("Fog::Storage::Google => ##{get_object_url} is deprecated, use ##{get_object_https_url} instead[/] [light_black](#{caller.first})")
+          Fog::Logger.deprecation("Fog::Storage::Google => #get_object_url is deprecated, use #get_object_https_url instead[/] [light_black](#{caller(1..1).first})")
           get_object_https_url(bucket_name, object_name, expires)
         end
       end


### PR DESCRIPTION
`get_object_url` invokes itself as logging message causing an `ArgumentError`