### PR TITLE
Fix instance workflow

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,11 +55,6 @@ Style/GuardClause:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
   Enabled: false
   MinBodyLength: 1
-Style/IfUnlessModifier:
-  Description: Favor modifier if/unless usage when you have a single-line body.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
-  Enabled: false
-  MaxLineLength: 80
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.
   Enabled: false
@@ -240,9 +235,6 @@ Lint/EachWithObjectArgument:
 Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
-  Enabled: false
-Lint/LiteralInCondition:
-  Description: Checks of literals used in conditions.
   Enabled: false
 Lint/LiteralInInterpolation:
   Description: Checks for literals used in interpolation.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,11 +55,6 @@ Style/GuardClause:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
   Enabled: false
   MinBodyLength: 1
-Style/IfUnlessModifier:
-  Description: Favor modifier if/unless usage when you have a single-line body.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
-  Enabled: false
-  MaxLineLength: 80
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,11 @@ Style/GuardClause:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
   Enabled: false
   MinBodyLength: 1
+Style/IfUnlessModifier:
+  Description: Favor modifier if/unless usage when you have a single-line body.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
+  Enabled: false
+  MaxLineLength: 80
 Style/OptionHash:
   Description: Don't use option hashes when you can use keyword arguments.
   Enabled: false
@@ -235,6 +240,9 @@ Lint/EachWithObjectArgument:
 Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
+  Enabled: false
+Lint/LiteralInCondition:
+  Description: Checks of literals used in conditions.
   Enabled: false
 Lint/LiteralInInterpolation:
   Description: Checks for literals used in interpolation.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 cache: bundler
+before_install:
+  # Added gem update due to travis-ci/issues/8969
+  - gem update --system
+  - gem --version
 sudo: false
 dist: trusty
 matrix:

--- a/examples/create_instance.rb
+++ b/examples/create_instance.rb
@@ -13,7 +13,7 @@ def test
     :name => "fog-smoke-test-#{Time.now.to_i}",
     :size_gb => 10,
     :zone_name => "us-central1-f",
-    :source_image => "debian-8-jessie-v20161215"
+    :source_image => "debian-8-jessie-v20180329"
   )
 
   disk.wait_for { disk.ready? }

--- a/examples/get_list_images.rb
+++ b/examples/get_list_images.rb
@@ -23,7 +23,7 @@ def test
 
   puts "Fetching a single image from a global project..."
   puts "------------------------------------------------"
-  img = connection.images.get("debian-8-jessie-v20161215")
+  img = connection.images.get("debian-8-jessie-v20180329")
   raise "Could not GET the image" unless img
   puts img.inspect
 

--- a/examples/load-balance.rb
+++ b/examples/load-balance.rb
@@ -24,7 +24,7 @@ def test
         :name => "#{name}-#{i}",
         :size_gb => 10,
         :zone_name => zone,
-        :source_image => "debian-8-jessie-v20160718"
+        :source_image => "debian-8-jessie-v20180329"
       )
       disk.wait_for { disk.ready? }
     rescue

--- a/examples/metadata.rb
+++ b/examples/metadata.rb
@@ -15,7 +15,7 @@ def test
     :name => name,
     :size_gb => 10,
     :zone_name => "us-central1-f",
-    :source_image => "debian-8-jessie-v20161215"
+    :source_image => "debian-8-jessie-v20180329"
   )
 
   disk.wait_for { disk.ready? }

--- a/examples/network.rb
+++ b/examples/network.rb
@@ -24,7 +24,7 @@ def test
     :name => name,
     :size_gb => 10,
     :zone_name => "us-central1-a",
-    :source_image => "debian-8-jessie-v20161215"
+    :source_image => "debian-8-jessie-v20180329"
   )
 
   disk.wait_for { disk.ready? }

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "osrcry"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop", ">= 0.54.0"
   spec.add_development_dependency "shindo"

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "osrcry"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "rubocop", ">= 0.54.0"
   spec.add_development_dependency "shindo"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rubocop", ">= 0.54.0"
+  spec.add_development_dependency "rubocop"
   spec.add_development_dependency "shindo"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"

--- a/lib/fog/compute/google/requests/insert_disk.rb
+++ b/lib/fog/compute/google/requests/insert_disk.rb
@@ -13,24 +13,31 @@ module Fog
         #
         # @param disk_name [String] Name of the disk to create
         # @param zone_name [String] Zone the disk reside in
-        # @param image_name [String] Optional image name to create the disk from
+        # @param source_image [String] Optional self_link or family formatted url of the image to
+        # create the disk from, see https://cloud.google.com/compute/docs/reference/latest/disks/insert
         # @param opts [Hash] Optional hash of options
         # @option options [String] size_gb Number of GB to allocate to an empty disk
         # @option options [String] source_snapshot Snapshot to create the disk from
         # @option options [String] description Human friendly description of the disk
         # @option options [String] type URL of the disk type resource describing which disk type to use
-        def insert_disk(disk_name, zone, image_name = nil,
+        # TODO: change source_image to keyword argument in 2.0 and properly deprecate
+        def insert_disk(disk_name, zone, source_image = nil,
                         description: nil, type: nil, size_gb: nil,
                         source_snapshot: nil, **_opts)
+
+          unless source_image.include?("projects/")
+            raise ArgumentError.new("source_image needs to be a self-link formatted or specify a family")
+          end
+
           disk = ::Google::Apis::ComputeV1::Disk.new(
             :name => disk_name,
             :description => description,
             :type => type,
             :size_gb => size_gb,
-            :source_snapshot => source_snapshot
+            :source_snapshot => source_snapshot,
+            :source_image => source_image
           )
-          @compute.insert_disk(@project, zone.split("/")[-1], disk,
-                               :source_image => image_name)
+          @compute.insert_disk(@project, zone.split("/")[-1], disk)
         end
       end
     end

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -1,3 +1,9 @@
 require "rubocop/rake_task"
 
 RuboCop::RakeTask.new(:lint)
+
+namespace :lint do
+  task :changed do
+    sh("git status --porcelain | cut -c4- | grep '.rb' | xargs rubocop")
+  end
+end

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -1,9 +1,3 @@
 require "rubocop/rake_task"
 
 RuboCop::RakeTask.new(:lint)
-
-namespace :lint do
-  task :changed do
-    sh("git status --porcelain | cut -c4- | grep '.rb' | xargs rubocop")
-  end
-end


### PR DESCRIPTION
Fixing the disk part of #315 

Mainly:
- Added logic to get the image from name if the format is not
  compatible with new Google API Client and added a
  user-friendly error if image is specified incorrectly

- Disk autogenerated object already accepts :source_image as an
  option so removing it from request parameters

- Zone is already set in parameters so should not be duped in
  options