### PR TITLE
Fix instance workflow - take 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 cache: bundler
+before_install:
+  # Added gem update due to travis-ci/issues/8969
+  - gem update --system
+  - gem --version
 sudo: false
 dist: trusty
 matrix:

--- a/examples/create_instance.rb
+++ b/examples/create_instance.rb
@@ -13,7 +13,7 @@ def test
     :name => "fog-smoke-test-#{Time.now.to_i}",
     :size_gb => 10,
     :zone_name => "us-central1-f",
-    :source_image => "debian-8-jessie-v20161215"
+    :source_image => "debian-8-jessie-v20180329"
   )
 
   disk.wait_for { disk.ready? }

--- a/examples/get_list_images.rb
+++ b/examples/get_list_images.rb
@@ -23,7 +23,7 @@ def test
 
   puts "Fetching a single image from a global project..."
   puts "------------------------------------------------"
-  img = connection.images.get("debian-8-jessie-v20161215")
+  img = connection.images.get("debian-8-jessie-v20180329")
   raise "Could not GET the image" unless img
   puts img.inspect
 

--- a/examples/load-balance.rb
+++ b/examples/load-balance.rb
@@ -24,7 +24,7 @@ def test
         :name => "#{name}-#{i}",
         :size_gb => 10,
         :zone_name => zone,
-        :source_image => "debian-8-jessie-v20160718"
+        :source_image => "debian-8-jessie-v20180329"
       )
       disk.wait_for { disk.ready? }
     rescue

--- a/examples/metadata.rb
+++ b/examples/metadata.rb
@@ -15,7 +15,7 @@ def test
     :name => name,
     :size_gb => 10,
     :zone_name => "us-central1-f",
-    :source_image => "debian-8-jessie-v20161215"
+    :source_image => "debian-8-jessie-v20180329"
   )
 
   disk.wait_for { disk.ready? }

--- a/examples/network.rb
+++ b/examples/network.rb
@@ -24,7 +24,7 @@ def test
     :name => name,
     :size_gb => 10,
     :zone_name => "us-central1-a",
-    :source_image => "debian-8-jessie-v20161215"
+    :source_image => "debian-8-jessie-v20180329"
   )
 
   disk.wait_for { disk.ready? }

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "osrcry"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "shindo"

--- a/lib/fog/compute/google/requests/insert_disk.rb
+++ b/lib/fog/compute/google/requests/insert_disk.rb
@@ -13,24 +13,31 @@ module Fog
         #
         # @param disk_name [String] Name of the disk to create
         # @param zone_name [String] Zone the disk reside in
-        # @param image_name [String] Optional image name to create the disk from
+        # @param source_image [String] Optional self_link or family formatted url of the image to
+        # create the disk from, see https://cloud.google.com/compute/docs/reference/latest/disks/insert
         # @param opts [Hash] Optional hash of options
         # @option options [String] size_gb Number of GB to allocate to an empty disk
         # @option options [String] source_snapshot Snapshot to create the disk from
         # @option options [String] description Human friendly description of the disk
         # @option options [String] type URL of the disk type resource describing which disk type to use
-        def insert_disk(disk_name, zone, image_name = nil,
+        # TODO: change source_image to keyword argument in 2.0 and properly deprecate
+        def insert_disk(disk_name, zone, source_image = nil,
                         description: nil, type: nil, size_gb: nil,
                         source_snapshot: nil, **_opts)
+
+          unless source_image.include?("projects/")
+            raise ArgumentError.new("source_image needs to be a self-link formatted or specify a family")
+          end
+
           disk = ::Google::Apis::ComputeV1::Disk.new(
             :name => disk_name,
             :description => description,
             :type => type,
             :size_gb => size_gb,
-            :source_snapshot => source_snapshot
+            :source_snapshot => source_snapshot,
+            :source_image => source_image
           )
-          @compute.insert_disk(@project, zone.split("/")[-1], disk,
-                               :source_image => image_name)
+          @compute.insert_disk(@project, zone.split("/")[-1], disk)
         end
       end
     end


### PR DESCRIPTION
Fixing the disk part of #315, recreating the PR without my changes to rubocop to make sure I'm not causing HoundCI to act up.

Mainly:

Added logic to get the image from name if the format is not
compatible with new Google API Client and added a
user-friendly error if image is specified incorrectly

Disk autogenerated object already accepts :source_image as an
option so removing it from request parameters

Zone is already set in parameters so should not be duped in
options