### PR TITLE
Listing all subnetworks symbol key

### DIFF
--- a/lib/fog/compute/google/models/subnetworks.rb
+++ b/lib/fog/compute/google/models/subnetworks.rb
@@ -15,7 +15,7 @@ module Fog
           if region.nil?
             data = []
             service.list_aggregated_subnetworks(filters).to_h[:items].each_value do |region_obj|
-              data.concat(region_obj["subnetworks"]) if region_obj["subnetworks"]
+              data.concat(region_obj[:subnetworks]) if region_obj[:subnetworks]
             end
           else
             data = service.list_subnetworks(region, filters).to_h[:items]


### PR DESCRIPTION
The fog was unable to list subnetworks using the `connection.subnetworks.all` call.

In recent versions of `google-api-client`, the hash response keys had been changed from strings to symbols. This is one of uncaught appearances. :wink: 
