### PR TITLE
Add support for using predefined ACLs, fixes #324

### DIFF
--- a/lib/fog/storage/google_xml/models/directory.rb
+++ b/lib/fog/storage/google_xml/models/directory.rb
@@ -7,9 +7,8 @@ module Fog
         attribute :creation_date, :aliases => "CreationDate"
 
         def acl=(new_acl)
-          valid_acls = ["private", "public-read", "public-read-write", "authenticated-read"]
-          unless valid_acls.include?(new_acl)
-            raise ArgumentError.new("acl must be one of [#{valid_acls.join(', ')}]")
+          unless Utils::VALID_ACLS.include?(new_acl)
+            raise ArgumentError.new("acl must be one of [#{Utils::VALID_ACLS.join(', ')}]")
           end
           @acl = new_acl
         end

--- a/lib/fog/storage/google_xml/models/file.rb
+++ b/lib/fog/storage/google_xml/models/file.rb
@@ -17,20 +17,9 @@ module Fog
         attribute :owner,               :aliases => "Owner"
         attribute :storage_class,       :aliases => ["x-goog-storage-class", "StorageClass"]
 
-        # https://cloud.google.com/storage/docs/access-control#predefined-acl
-        VALID_ACLS = [
-          "authenticated-read",
-          "bucket-owner-full-control",
-          "bucket-owner-read",
-          "private",
-          "project-private",
-          "public-read",
-          "public-read-write"
-        ].freeze
-
         def acl=(new_acl)
-          unless VALID_ACLS.include?(new_acl)
-            raise ArgumentError.new("acl must be one of [#{VALID_ACLS.join(', ')}]")
+          unless Utils::VALID_ACLS.include?(new_acl)
+            raise ArgumentError.new("acl must be one of [#{Utils::VALID_ACLS.join(', ')}]")
           end
           @acl = new_acl
         end

--- a/lib/fog/storage/google_xml/requests/put_bucket.rb
+++ b/lib/fog/storage/google_xml/requests/put_bucket.rb
@@ -38,7 +38,7 @@ module Fog
       class Mock
         def put_bucket(bucket_name, options = {})
           acl = options["x-goog-acl"] || "private"
-          if !["private", "public-read", "public-read-write", "authenticated-read"].include?(acl)
+          if !Utils::VALID_ACLS.include?(acl)
             raise Excon::Errors::BadRequest.new("invalid x-goog-acl")
           else
             data[:acls][:bucket][bucket_name] = self.class.acls(options[acl])

--- a/lib/fog/storage/google_xml/requests/put_object.rb
+++ b/lib/fog/storage/google_xml/requests/put_object.rb
@@ -38,7 +38,7 @@ module Fog
       class Mock
         def put_object(bucket_name, object_name, data, options = {})
           acl = options["x-goog-acl"] || "private"
-          if !["private", "public-read", "public-read-write", "authenticated-read"].include?(acl)
+          if !Utils::VALID_ACLS.include?(acl)
             raise Excon::Errors::BadRequest.new("invalid x-goog-acl")
           else
             self.data[:acls][:object][bucket_name] ||= {}

--- a/lib/fog/storage/google_xml/requests/put_object_acl.rb
+++ b/lib/fog/storage/google_xml/requests/put_object_acl.rb
@@ -39,10 +39,10 @@ module Fog
 </AccessControlList>
 DATA
           else
-            if !%w(private bucket-owner-read bucket-owner-full-control project-private authenticated-read public-read public-read-write).include?(acl)
-              raise Excon::Errors::BadRequest.new('invalid x-goog-acl')
+            unless %w(private bucket-owner-read bucket-owner-full-control project-private authenticated-read public-read public-read-write).include?(acl)
+              raise Excon::Errors::BadRequest.new("invalid x-goog-acl")
             end
-            headers['x-goog-acl'] = acl
+            headers["x-goog-acl"] = acl
           end
 
           request(:body     => data,

--- a/lib/fog/storage/google_xml/requests/put_object_acl.rb
+++ b/lib/fog/storage/google_xml/requests/put_object_acl.rb
@@ -2,6 +2,15 @@ module Fog
   module Storage
     class GoogleXML
       class Real
+        VALID_ACLS = [
+          "authenticated-read",
+          "bucket-owner-full-control",
+          "bucket-owner-read",
+          "private",
+          "project-private",
+          "public-read",
+          "public-read-write"
+        ].freeze
         # TODO: move this methods to helper to use them with put_bucket_acl request
         def tag(name, value)
           "<#{name}>#{value}</#{name}>"
@@ -38,11 +47,10 @@ module Fog
   </Entries>
 </AccessControlList>
 DATA
-          else
-            unless %w(private bucket-owner-read bucket-owner-full-control project-private authenticated-read public-read public-read-write).include?(acl)
-              raise Excon::Errors::BadRequest.new("invalid x-goog-acl")
-            end
+          elsif acl.is_a?(String) && VALID_ACLS.include?(acl)
             headers["x-goog-acl"] = acl
+          else
+            raise Excon::Errors::BadRequest.new("invalid x-goog-acl")
           end
 
           request(:body     => data,

--- a/lib/fog/storage/google_xml/requests/put_object_acl.rb
+++ b/lib/fog/storage/google_xml/requests/put_object_acl.rb
@@ -2,15 +2,6 @@ module Fog
   module Storage
     class GoogleXML
       class Real
-        VALID_ACLS = [
-          "authenticated-read",
-          "bucket-owner-full-control",
-          "bucket-owner-read",
-          "private",
-          "project-private",
-          "public-read",
-          "public-read-write"
-        ].freeze
         # TODO: move this methods to helper to use them with put_bucket_acl request
         def tag(name, value)
           "<#{name}>#{value}</#{name}>"
@@ -47,7 +38,7 @@ module Fog
   </Entries>
 </AccessControlList>
 DATA
-          elsif acl.is_a?(String) && VALID_ACLS.include?(acl)
+          elsif acl.is_a?(String) && Utils::VALID_ACLS.include?(acl)
             headers["x-goog-acl"] = acl
           else
             raise Excon::Errors::BadRequest.new("invalid x-goog-acl")

--- a/lib/fog/storage/google_xml/utils.rb
+++ b/lib/fog/storage/google_xml/utils.rb
@@ -2,6 +2,17 @@ module Fog
   module Storage
     class GoogleXML
       module Utils
+        # https://cloud.google.com/storage/docs/access-control#predefined-acl
+        VALID_ACLS = [
+          "authenticated-read",
+          "bucket-owner-full-control",
+          "bucket-owner-read",
+          "private",
+          "project-private",
+          "public-read",
+          "public-read-write"
+        ].freeze
+
         def http_url(params, expires)
           "http://" << host_path_query(params, expires)
         end


### PR DESCRIPTION
As per issue #324, I decided to make a start on this functionality and would like to know what folks think. I'm not sure which tests need writing and where, especially since things are migrating to minitest. Some guidance would be appreciated.

Also, the changes introduced here are pretty much entirely copied from https://github.com/fog/fog-aws/blob/master/lib/fog/aws/requests/storage/put_object_acl.rb#L39.