### PR TITLE
WIP - Parallelize CI, update run-int task

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,5 +1,5 @@
 jobs:
-  - name: pr-integrate
+  - name: integration-tests-compute
     plan:
       - get: fog-google-src
         resource: pull-request
@@ -11,9 +11,89 @@ jobs:
       - task: full-integration-tests
         file: fog-google-src/ci/tasks/run-int.yml
         params:
+          rake_task: test:compute
           google_project: {{google_project}}
           google_json_key_data: {{google_json_key_data}}
           google_client_email: {{google_client_email}}
+
+  - name: integration-tests-monitoring
+    plan:
+      - get: fog-google-src
+        resource: pull-request
+        version: every
+        trigger: true
+      - put: pull-request
+        params: {path: fog-google-src, status: pending}
+
+      - task: full-integration-tests
+        file: fog-google-src/ci/tasks/run-int.yml
+        params:
+          rake_task: test:monitoring
+          google_project: {{google_project}}
+          google_json_key_data: {{google_json_key_data}}
+          google_client_email: {{google_client_email}}
+
+  - name: integration-tests-pubsub
+    plan:
+      - get: fog-google-src
+        resource: pull-request
+        version: every
+        trigger: true
+      - put: pull-request
+        params: {path: fog-google-src, status: pending}
+
+      - task: full-integration-tests
+        file: fog-google-src/ci/tasks/run-int.yml
+        params:
+          rake_task: test:pubsub
+          google_project: {{google_project}}
+          google_json_key_data: {{google_json_key_data}}
+          google_client_email: {{google_client_email}}
+
+  - name: integration-tests-sql
+    plan:
+      - get: fog-google-src
+        resource: pull-request
+        version: every
+        trigger: true
+      - put: pull-request
+        params: {path: fog-google-src, status: pending}
+
+      - task: full-integration-tests
+        file: fog-google-src/ci/tasks/run-int.yml
+        params:
+          rake_task: test:sql
+          google_project: {{google_project}}
+          google_json_key_data: {{google_json_key_data}}
+          google_client_email: {{google_client_email}}
+
+  - name: integration-tests-storage
+    plan:
+      - get: fog-google-src
+        resource: pull-request
+        version: every
+        trigger: true
+      - put: pull-request
+        params: {path: fog-google-src, status: pending}
+
+      - task: full-integration-tests
+        file: fog-google-src/ci/tasks/run-int.yml
+        params:
+          rake_task: test:storage
+          google_project: {{google_project}}
+          google_json_key_data: {{google_json_key_data}}
+          google_client_email: {{google_client_email}}
+
+  - name: github-pr-aggregator
+    plan:
+      - get: fog-google-src
+        resource: pull-request
+        passed: [integration-tests-storage,
+                 integration-tests-sql,
+                 integration-tests-pubsub,
+                 integration-tests-monitoring,
+                 integration-tests-compute]
+        trigger: true
         on_success:
           put: pull-request
           params:

--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -15,6 +15,7 @@ popd > /dev/null
 check_param google_project
 check_param google_client_email
 check_param google_json_key_data
+check_param rake_task
 
 echo $google_json_key_data > `pwd`/service_account_key.json
 
@@ -29,6 +30,6 @@ pushd ${release_dir} > /dev/null
 
 bundle install
 
-FOG_MOCK=false rake test
+FOG_MOCK=false rake ${rake_task}
 
 popd > /dev/null

--- a/ci/tasks/run-int.yml
+++ b/ci/tasks/run-int.yml
@@ -9,6 +9,7 @@ inputs:
 run:
   path: src/fog-google/ci/tasks/run-int.sh
 params:
+  rake_task: replace-me
   google_project: replace-me
   google_client_email: replace-me
   google_json_key_data: |

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -1,13 +1,7 @@
 require "rake/testtask"
 
 Rake::TestTask.new do |t|
-  t.libs << "test"
-  t.pattern = File.join("test", "**", "test_*.rb")
-  t.warning = false
-end
-
-Rake::TestTask.new do |t|
-  t.name = "compute"
+  t.description = "Run all integration tests"
   t.libs << "test"
   t.pattern = File.join("test", "**", "test_*.rb")
   t.warning = false
@@ -19,8 +13,15 @@ namespace :test do
     sh("export FOG_MOCK=#{mock} && bundle exec shindont")
   end
 
+  desc "Run all integration tests in parallel"
+  multitask :parallel => ["test:compute",
+                          "test:monitoring",
+                          "test:pubsub",
+                          "test:sql",
+                          "test:storage"]
   Rake::TestTask.new do |t|
     t.name = "compute"
+    t.description = "Run Compute API tests"
     t.libs << "test"
     t.pattern = FileList['test/integration/compute/test_*.rb']
     t.warning = false
@@ -29,6 +30,7 @@ namespace :test do
 
   Rake::TestTask.new do |t|
     t.name = "monitoring"
+    t.description = "Run Monitoring API tests"
     t.libs << "test"
     t.pattern = FileList['test/integration/monitoring/test_*.rb']
     t.warning = false
@@ -37,6 +39,7 @@ namespace :test do
 
   Rake::TestTask.new do |t|
     t.name = "pubsub"
+    t.description = "Run PubSub API tests"
     t.libs << "test"
     t.pattern = FileList['test/integration/pubsub/test_*.rb']
     t.warning = false
@@ -45,6 +48,7 @@ namespace :test do
 
   Rake::TestTask.new do |t|
     t.name = "sql"
+    t.description = "Run SQL API tests"
     t.libs << "test"
     t.pattern = FileList['test/integration/sql/test_*.rb']
     t.warning = false
@@ -53,6 +57,7 @@ namespace :test do
 
   Rake::TestTask.new do |t|
     t.name = "storage"
+    t.description = "Run Storage API tests"
     t.libs << "test"
     t.pattern = FileList['test/integration/storage/test_*.rb']
     t.warning = false

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -38,14 +38,6 @@ namespace :test do
   Rake::TestTask.new do |t|
     t.name = "pubsub"
     t.libs << "test"
-    t.pattern = FileList['test/integration/monitoring/test_*.rb']
-    t.warning = false
-    t.verbose = true
-  end
-
-  Rake::TestTask.new do |t|
-    t.name = "pubsub"
-    t.libs << "test"
     t.pattern = FileList['test/integration/pubsub/test_*.rb']
     t.warning = false
     t.verbose = true


### PR DESCRIPTION
- Parallelising our CI, pipeline will now be running jobs in parallel and look something like this:

<img width="1040" alt="screen shot 2018-05-23 at 13 52 44" src="https://user-images.githubusercontent.com/2083229/40462917-947c6388-5f55-11e8-88eb-dbe03ab90ae1.png">

, allowing to get the results for relevant sections ASAP and compartmentalising test so they can be rerun if needed (in case of underlying API flakiness or collisions).

- Added separate test tasks for each section of fog for quicker testing:
```
rake test               # Run all integration tests
rake test:parallel      # Run all integration tests in parallel

rake test:compute       # Run Compute API tests
rake test:monitoring    # Run Monitoring API tests
rake test:pubsub        # Run PubSub API tests
rake test:sql           # Run SQL API tests
rake test:storage       # Run Storage API tests
```
- Added a `rake test:parallel` task, which has about 3X performance with a caveat of ugly (but useful) output.

@icco FYI - this should improve our testing situation somewhat.