### PR TITLE
Fix get_health when called with an instance name

### DIFF
--- a/lib/fog/compute/google/models/target_pool.rb
+++ b/lib/fog/compute/google/models/target_pool.rb
@@ -104,7 +104,7 @@ module Fog
             instance = service.servers.get(instance_name)
             data = service.get_target_pool_health(identity, region, instance.self_link)
                           .to_h[:health_status] || []
-            results = [instance.self_link, data]
+            results = [[instance.self_link, data]]
           else
             results = instances.map do |self_link|
               data = service.get_target_pool_health(identity, region, self_link)


### PR DESCRIPTION
Without that, the Hash[results] does not work as expected.
Another option is to not return the same signature when an instance name is specified (data can be returned directly)