### PR TITLE
Added test on put_object with `nil` as object body

### DIFF
--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -15,6 +15,12 @@ class TestStorageRequests < StorageShared
     assert_equal(temp_file_content, object[:body])
   end
 
+  def test_put_object_nil
+    assert_raises(ArgumentError) do
+      @client.put_object(some_bucket_name, new_object_name, nil)
+    end
+  end
+
   def test_put_object_file
     object_name = new_object_name
     expected_body = "A file body"


### PR DESCRIPTION
We had some unclear situation while were testing file uploads. When we sent `nil` we got `ClientError` stating that URL is bad and should be starting from `/upload`. All of that were caused by invalid/unexpected command being created https://github.com/google/google-api-ruby-client/blob/e3b8c800d649da00748d4605d847b342480ecc73/generated/google/apis/storage_v1/service.rb#L1795