### PR TITLE
Fix remove google-containers images listing

### DIFF
--- a/lib/fog/compute/google/models/images.rb
+++ b/lib/fog/compute/google/models/images.rb
@@ -19,7 +19,6 @@ module Fog
           ubuntu-os-cloud
           windows-cloud
           windows-sql-cloud
-          google-containers
           opensuse-cloud
         ).freeze
 


### PR DESCRIPTION
Google recently removed `google-containers` from the [Public images list](https://cloud.google.com/compute/docs/images).

Any call to `.images.all` results in an exception:

```
> compute = ::Fog::Compute.new(...)
> compute.images.all
...
Sending HTTP get https://www.googleapis.com/compute/v1/projects/google-containers/global/images?
403
...
Google::Apis::ClientError: accessNotConfigured: Access Not Configured. Compute Engine API has not been used in project 255964991331 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/compute.googleapis.com/overview?project=255964991331 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
from /home/tcoufal/.rbenv/versions/2.4.4/lib/ruby/gems/2.4.0/gems/google-api-client-0.23.0/lib/google/apis/core/http_command.rb:218:in `check_status'
```

Fix  removes the `google-containers` from the list of pulled projects.