### PR TITLE
Switch to Fog::Google.escape to fix whitespace

### DIFF
--- a/lib/fog/storage/google_xml/utils.rb
+++ b/lib/fog/storage/google_xml/utils.rb
@@ -30,7 +30,7 @@ module Fog
 
         def host_path_query(params, expires)
           params[:headers]["Date"] = expires.to_i
-          params[:path] = CGI.escape(params[:path]).gsub("%2F", "/")
+          params[:path] = Fog::Google.escape(params[:path]).gsub("%2F", "/")
           query = [params[:query]].compact
           query << "GoogleAccessId=#{@google_storage_access_key_id}"
           query << "Signature=#{CGI.escape(signature(params))}"

--- a/test/unit/storage/test_xml_requests.rb
+++ b/test/unit/storage/test_xml_requests.rb
@@ -1,0 +1,24 @@
+require "helpers/test_helper"
+
+class UnitTestServer < MiniTest::Test
+  def setup
+    Fog.mock!
+    @client = Fog::Storage.new(provider: "google",
+                               google_storage_access_key_id: "",
+                               google_storage_secret_access_key: "")
+  end
+
+  def teardown
+    Fog.unmock!
+  end
+
+  def test_put_url_path_is_properly_escaped
+    url = @client.put_object_url("bucket",
+                                 "just some file.json",
+                                 Time.now + 2 * 60,
+                                 "Content-Type" => "application/json")
+
+    assert_match(/just%20some%20file\.json/, url,
+                 "space should be escaped with '%20'")
+  end
+end


### PR DESCRIPTION
This should fix ‘+’ being inserted instead of %20 when using spaces in filename.

Fixes #357