### PR TITLE
Fixing Fog::Server user/sshkey workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Next release (1.6.0)
+
+### User-facing
+
+#### Added
+
+- \#361 `Fog::Compute::Google::Server` now recognises `network_ip` attribute to specify internal IP [mattimatti]
+
+#### Fixed
+
+- \#359 Fix whitespace escaping in XML Storage methods [temikus]
+- \#366 Fixing `Server` model to properly accept `:private_key_path` and `:public_key_path` attributes again. [temikus]
+
+### Development changes
+
+#### Fixed
+
+- \#363 Fixed flaky Monitoring tests [temikus]
+
 ## 1.5.0
 
 ### User-facing

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -445,6 +445,11 @@ module Fog
           requires :disks
           requires :zone
 
+          generate_ssh_key_metadata(self.username, self.public_key) if self.public_key
+
+          # XXX HACK This is a relic of 1.0 change that for some reason added those arguments
+          # to `save` method. This is left in place to keep things backwards-compatible
+          # TODO(2.0): Remove arguments from save
           generate_ssh_key_metadata(username, public_key) if public_key
 
           options = attributes.reject { |_, v| v.nil? }

--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -43,9 +43,6 @@ module Fog
         end
 
         def bootstrap(public_key_path: nil, **opts)
-          user = ENV["USER"]
-          public_key = get_public_key(public_key_path)
-
           name = "fog-#{Time.now.to_i}"
           zone_name = "us-central1-f"
 
@@ -69,7 +66,9 @@ module Fog
           data = opts.merge(
             :name => name,
             :zone => zone_name,
-            :disks => disks
+            :disks => disks,
+            :public_key_path => get_public_key(public_key_path),
+            :username => ENV["USER"]
           )
           data[:machine_type] = "n1-standard-1" unless data[:machine_type]
 

--- a/test/unit/compute/test_server.rb
+++ b/test/unit/compute/test_server.rb
@@ -1,8 +1,6 @@
 require "helpers/test_helper"
-# require testing stuff 
 
 class UnitTestServer < MiniTest::Test
-
   def setup
     Fog.mock!
     @client = Fog::Compute.new(:provider => "Google", :google_project => "foo")
@@ -17,11 +15,11 @@ class UnitTestServer < MiniTest::Test
 
     File.stub :read, key do
       server = Fog::Compute::Google::Server.new(
-          :name => "foo",
-          :machine_type => "bar",
-          :disks => ["baz"],
-          :zone => "foo",
-          :public_key_path => key
+        :name => "foo",
+        :machine_type => "bar",
+        :disks => ["baz"],
+        :zone => "foo",
+        :public_key_path => key
       )
       assert_equal(server.public_key, key,
                    "Fog::Compute::Google::Server loads public_key properly")

--- a/test/unit/compute/test_server.rb
+++ b/test/unit/compute/test_server.rb
@@ -1,0 +1,30 @@
+require "helpers/test_helper"
+# require testing stuff 
+
+class UnitTestServer < MiniTest::Test
+
+  def setup
+    Fog.mock!
+    @client = Fog::Compute.new(:provider => "Google", :google_project => "foo")
+  end
+
+  def teardown
+    Fog.unmock!
+  end
+
+  def test_if_server_accepts_ssh_keys
+    key = "ssh-rsa IAMNOTAREALSSHKEYAMA== user@host.subdomain.example.com"
+
+    File.stub :read, key do
+      server = Fog::Compute::Google::Server.new(
+          :name => "foo",
+          :machine_type => "bar",
+          :disks => ["baz"],
+          :zone => "foo",
+          :public_key_path => key
+      )
+      assert_equal(server.public_key, key,
+                   "Fog::Compute::Google::Server loads public_key properly")
+    end
+  end
+end

--- a/test/unit/storage/test_xml_requests.rb
+++ b/test/unit/storage/test_xml_requests.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestServer < MiniTest::Test
+class UnitTestXMLRequests < MiniTest::Test
   def setup
     Fog.mock!
     @client = Fog::Storage.new(provider: "google",


### PR DESCRIPTION
For some reason those were abandoned in 1.0, so core examples and `bootstrap` no longer worked.
E.g. the following no longer provisioned the keys properly:

```
 server = connection.servers.create(
    :name => "fog-smoke-test-#{Time.now.to_i}",
    :disks => [disk],
    :machine_type => "n1-standard-1",
    :private_key_path => File.expand_path("~/.ssh/id_rsa"),
    :public_key_path => File.expand_path("~/.ssh/id_rsa.pub"),
    :zone => "us-central1-f",
    :username => ENV["USER"],
    :tags => ["fog"],
    :service_accounts => { :scopes => %w(sql-admin bigquery https://www.googleapis.com/auth/compute) }
  )
```
This patch will make sure `:private_key_path` and `:public_key_path` are processed properly again.

Fixing #362 

Not even mentioning that `save()` shouldn't have had arguments in the first place.
But that's going to be fixed by a larger effort in 2.0 #365 