### PR TITLE
Bootstrap autodelete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,20 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 - \#338 `Fog::Google::SQL` resources are now created and destroyed synchronously by default. 
 You can override it in a standard manner by passing a parameter to async method, e.g.:
- `Fog::Google::SQL::Instance.create(true)`
+ `Fog::Google::SQL::Instance.create(true)`[temikus]
+- \#367 `Fog::Compute::Google::Server.bootstrap` now creates instances with disks that automatically delete
+on instance shutdown.[temikus]
 
 #### Added
 
-- \#361 `Fog::Compute::Google::Server` now recognises `network_ip` attribute to specify internal IP [mattimatti]
+- \#361 `Fog::Compute::Google::Server` now recognises `network_ip` attribute to specify internal IP. [mattimatti]
 
 #### Fixed
 
-- \#338 Fixed SQL Users model workflow
+- \#338 Fixed SQL Users model workflow [temikus]
 - \#359 Fix whitespace escaping in XML Storage methods [temikus]
 - \#366 Fixing `Server` model to properly accept `:private_key_path` and `:public_key_path` attributes again. [temikus]
+- \#367 `Fog::Compute::Google::Server.bootstrap` parameters are now properly merged with default ones. [tesmikus]
 
 ### Development changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 - \#338 `Fog::Google::SQL` resources are now created and destroyed synchronously by default. 
 You can override it in a standard manner by passing a parameter to async method, e.g.:
- `Fog::Google::SQL::Instance.create(true)`[temikus]
-- \#367 `Fog::Compute::Google::Server.bootstrap` now creates instances with disks that automatically delete
-on instance shutdown.[temikus]
+ `Fog::Google::SQL::Instance.create(true)` [temikus]
+- \#367 `Fog::Compute::Google::Server.bootstrap` changes [temikus]
+  - Now creates instances with disks that automatically delete on instance shutdown.
+  - Now creates instances with a public IP address by default.
 
 #### Added
 

--- a/examples/bootstrap.rb
+++ b/examples/bootstrap.rb
@@ -1,18 +1,27 @@
 # All examples presume that you have a ~/.fog credentials file set up.
 # More info on it can be found here: http://fog.io/about/getting_started.html
+# Code can be ran by simply invoking `ruby bootstrap.rb`
+# Note: this example will require 'net-ssh' gem to be installed
 
 require "bundler"
 Bundler.require(:default, :development)
-# Uncomment this if you want to make real requests to GCE (you _will_ be billed!)
-# WebMock.disable!
 
-def test
-  connection = Fog::Compute.new(:provider => "Google")
+p "Connecting to google..."
+p "======================="
+connection = Fog::Compute.new(:provider => "Google")
 
-  server = connection.servers.bootstrap
+p "Bootstrapping a server..."
+p "========================="
+server = connection.servers.bootstrap
 
-  raise "Could not bootstrap sshable server." unless server.ssh("whoami")
-  raise "Could not delete server." unless server.destroy
-end
+p "Waiting for server to be sshable..."
+p "==================================="
+server.wait_for { sshable? }
 
-test
+p "Trying to send an SSH command..."
+p "================================"
+raise "Could not bootstrap sshable server." unless server.ssh("whoami")
+
+p "Deleting a server..."
+p "===================="
+raise "Could not delete server." unless server.destroy

--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -63,13 +63,14 @@ module Fog
             disks = [disk]
           end
 
-          data = opts.merge(
-            :name => name,
-            :zone => zone_name,
-            :disks => disks,
-            :public_key_path => get_public_key(public_key_path),
-            :username => ENV["USER"]
-          )
+          # Merge the options with the defaults, overwriting defaults
+          # if an option is provided
+          data = { :name => name,
+                   :zone => zone_name,
+                   :disks => disks,
+                   :public_key_path => get_public_key(public_key_path),
+                   :username => ENV["USER"] }.merge(opts)
+
           data[:machine_type] = "n1-standard-1" unless data[:machine_type]
 
           server = new(data)

--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -74,9 +74,10 @@ module Fog
           data[:machine_type] = "n1-standard-1" unless data[:machine_type]
 
           server = new(data)
-          server.save(:username => user, :public_key => public_key)
+          server.save
           # TODO: sshable? was removed, needs to be fixed for tests
           # server.wait_for { sshable? }
+          server.wait_for { ready? }
           server
         end
 

--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -63,12 +63,18 @@ module Fog
             disks = [disk]
           end
 
+          # TODO: Remove the network init when #360 is fixed
+          network = { :network => "global/networks/default",
+                      :access_configs => [{ :name => 'External NAT',
+                                            :type => 'ONE_TO_ONE_NAT' }] }
+
           # Merge the options with the defaults, overwriting defaults
           # if an option is provided
           data = { :name => name,
                    :zone => zone_name,
                    :disks => disks,
-                   :public_key_path => get_public_key(public_key_path),
+                   :network_interfaces => [network],
+                   :public_key => get_public_key(public_key_path),
                    :username => ENV["USER"] }.merge(opts)
 
           data[:machine_type] = "n1-standard-1" unless data[:machine_type]

--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -109,7 +109,7 @@ module Fog
           end
 
           if public_key_path.nil? || public_key_path.empty?
-            raise ArgumentError("cannot bootstrap instance without public key file")
+            raise Fog::Errors::Error.new("Cannot bootstrap instance without a public key")
           end
 
           File.read(File.expand_path(public_key_path))

--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -65,8 +65,8 @@ module Fog
 
           # TODO: Remove the network init when #360 is fixed
           network = { :network => "global/networks/default",
-                      :access_configs => [{ :name => 'External NAT',
-                                            :type => 'ONE_TO_ONE_NAT' }] }
+                      :access_configs => [{ :name => "External NAT",
+                                            :type => "ONE_TO_ONE_NAT" }] }
 
           # Merge the options with the defaults, overwriting defaults
           # if an option is provided
@@ -81,8 +81,6 @@ module Fog
 
           server = new(data)
           server.save
-          # TODO: sshable? was removed, needs to be fixed for tests
-          # server.wait_for { sshable? }
           server.wait_for { ready? }
 
           # Set the disk to be autodeleted

--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -78,6 +78,10 @@ module Fog
           # TODO: sshable? was removed, needs to be fixed for tests
           # server.wait_for { sshable? }
           server.wait_for { ready? }
+
+          # Set the disk to be autodeleted
+          server.set_disk_auto_delete(true)
+
           server
         end
 

--- a/test/integration/compute/test_servers.rb
+++ b/test/integration/compute/test_servers.rb
@@ -34,6 +34,13 @@ class TestServers < FogIntegrationTest
       assert_equal(key, server.public_key, "Bootstrapped server should have a public key set")
       assert_equal(user, server.username, "Bootstrapped server should have user set to #{user}")
       assert(boot_disk[:auto_delete], "Bootstrapped server should have disk set to autodelete")
+
+      network_adapter = server.network_interfaces.detect { |x| x.has_key?(:access_configs) }
+
+      refute_nil(network_adapter[:access_configs].detect { |x| x[:nat_ip] },
+                 "Bootstrapped server should have an external ip by default")
+    end
+  end
     end
   end
 end

--- a/test/integration/compute/test_servers.rb
+++ b/test/integration/compute/test_servers.rb
@@ -15,6 +15,23 @@ class TestServers < FogIntegrationTest
     server.wait_for { ready? }
     server.set_metadata({ "foo" => "bar", "baz" => "foo" }, false)
     assert_equal [{ :key => "foo", :value => "bar" },
-                  { :key=>"baz", :value=>"foo" }], server.metadata[:items]
+                  { :key => "baz", :value => "foo" }], server.metadata[:items]
+  end
+
+  def test_bootstrap
+    key = "ssh-rsa IAMNOTAREALSSHKEYAMA== user@host.subdomain.example.com"
+    user = "username"
+
+    File.stub :read, key do
+      # Name is set this way so it will be cleaned up by CollectionFactory
+      server = @subject.bootstrap({ :name => "#{CollectionFactory::PREFIX}-#{Time.now.to_i}",
+                                    :username => user })
+      boot_disk = server.disks.find { |disk| disk[:boot] }
+
+      assert_equal(server.status, "RUNNING", "Bootstrapped server should be running")
+      assert_equal(server.public_key, key, "Bootstrapped server should have a public key set")
+      assert_equal(server.username, user, "Bootstrapped server should have a user set")
+      assert(boot_disk[:auto_delete], "Bootstrapped server should have disk set to autodelete")
+    end
   end
 end

--- a/test/integration/compute/test_servers.rb
+++ b/test/integration/compute/test_servers.rb
@@ -41,6 +41,14 @@ class TestServers < FogIntegrationTest
                  "Bootstrapped server should have an external ip by default")
     end
   end
+
+  def test_bootstrap_fail
+    # Pretend the ssh key does not exist
+    File.stub :exist?, nil do
+      assert_raises(Fog::Errors::Error) {
+        @subject.bootstrap(:name => "#{CollectionFactory::PREFIX}-#{Time.now.to_i}",
+                           :public_key_path => nil)
+      }
     end
   end
 end

--- a/test/integration/compute/test_servers.rb
+++ b/test/integration/compute/test_servers.rb
@@ -24,9 +24,9 @@ class TestServers < FogIntegrationTest
 
     File.stub :read, key do
       # Name is set this way so it will be cleaned up by CollectionFactory
-      server = @subject.bootstrap({ :name => "#{CollectionFactory::PREFIX}-#{Time.now.to_i}",
-                                    :username => user })
-      boot_disk = server.disks.find { |disk| disk[:boot] }
+      server = @subject.bootstrap( :name => "#{CollectionFactory::PREFIX}-#{Time.now.to_i}",
+                                    :username => user )
+      boot_disk = server.disks.detect { |disk| disk[:boot] }
 
       assert_equal(server.status, "RUNNING", "Bootstrapped server should be running")
       assert_equal(server.public_key, key, "Bootstrapped server should have a public key set")

--- a/test/integration/compute/test_servers.rb
+++ b/test/integration/compute/test_servers.rb
@@ -24,13 +24,15 @@ class TestServers < FogIntegrationTest
 
     File.stub :read, key do
       # Name is set this way so it will be cleaned up by CollectionFactory
+      # Public_key_path is set to avoid stubbing out File.exist?
       server = @subject.bootstrap(:name => "#{CollectionFactory::PREFIX}-#{Time.now.to_i}",
-                                  :username => user)
+                                  :username => user,
+                                  :public_key_path => "foo")
       boot_disk = server.disks.detect { |disk| disk[:boot] }
 
-      assert_equal(server.status, "RUNNING", "Bootstrapped server should be running")
-      assert_equal(server.public_key, key, "Bootstrapped server should have a public key set")
-      assert_equal(server.username, user, "Bootstrapped server should have a user set")
+      assert_equal("RUNNING", server.status, "Bootstrapped server should be running")
+      assert_equal(key, server.public_key, "Bootstrapped server should have a public key set")
+      assert_equal(user, server.username, "Bootstrapped server should have user set to #{user}")
       assert(boot_disk[:auto_delete], "Bootstrapped server should have disk set to autodelete")
     end
   end

--- a/test/integration/compute/test_servers.rb
+++ b/test/integration/compute/test_servers.rb
@@ -24,8 +24,8 @@ class TestServers < FogIntegrationTest
 
     File.stub :read, key do
       # Name is set this way so it will be cleaned up by CollectionFactory
-      server = @subject.bootstrap( :name => "#{CollectionFactory::PREFIX}-#{Time.now.to_i}",
-                                    :username => user )
+      server = @subject.bootstrap(:name => "#{CollectionFactory::PREFIX}-#{Time.now.to_i}",
+                                  :username => user)
       boot_disk = server.disks.detect { |disk| disk[:boot] }
 
       assert_equal(server.status, "RUNNING", "Bootstrapped server should be running")


### PR DESCRIPTION
- Add tests for `Fog::Compute::Google::Server.bootstrap`
- Set disks to autodelete for servers created with `Fog::Compute::Google::Server.bootstrap`

+ some drive-by fixes to `.bootstrap`

Fixes #17 
