### PR TITLE
Add timeout options (Google::Apis::ClientOptions) to GoogleJSON API

### DIFF
--- a/lib/fog/storage/google_json.rb
+++ b/lib/fog/storage/google_json.rb
@@ -16,7 +16,10 @@ module Fog
         :google_key_location,
         :google_key_string,
         :google_json_key_location,
-        :google_json_key_string
+        :google_json_key_string,
+        :open_timeout_sec,
+        :read_timeout_sec,
+        :send_timeout_sec
       )
 
       # https://cloud.google.com/storage/docs/json_api/v1/

--- a/lib/fog/storage/google_json/real.rb
+++ b/lib/fog/storage/google_json/real.rb
@@ -15,6 +15,9 @@ module Fog
 
           @client = initialize_google_client(options)
           @storage_json = ::Google::Apis::StorageV1::StorageService.new
+          @storage_json.client_options.open_timeout_sec = options[:open_timeout_sec] if options[:open_timeout_sec]
+          @storage_json.client_options.read_timeout_sec = options[:read_timeout_sec] if options[:read_timeout_sec]
+          @storage_json.client_options.send_timeout_sec = options[:send_timeout_sec] if options[:send_timeout_sec]
         end
 
         def signature(params)


### PR DESCRIPTION
Currently, fog-google doesn't allow users to set timeout options when they upload objects to GCS.

This PR extends the support.

Here, in GitLab's usage, we can pass those params as the followings.

```
# gitlab.yml

connection:
  provider: Google
  google_project: xxx
  google_client_email: xxx
  google_json_key_location: xxx
  open_timeout_sec: 111
  read_timeout_sec: 123
  send_timeout_sec: 321
```