### PR TITLE
Deprecate Debian 8 references

### DIFF
--- a/examples/create_instance.rb
+++ b/examples/create_instance.rb
@@ -13,7 +13,7 @@ def test
     :name => "fog-smoke-test-#{Time.now.to_i}",
     :size_gb => 10,
     :zone => "us-central1-f",
-    :source_image => "debian-8-jessie-v20180329"
+    :source_image => "debian-9-stretch-v20180611"
   )
 
   disk.wait_for { disk.ready? }

--- a/examples/get_list_images.rb
+++ b/examples/get_list_images.rb
@@ -23,7 +23,7 @@ def test
 
   puts "Fetching a single image from a global project..."
   puts "------------------------------------------------"
-  img = connection.images.get("debian-8-jessie-v20180329")
+  img = connection.images.get("debian-9-stretch-v20180611")
   raise "Could not GET the image" unless img
   puts img.inspect
 

--- a/examples/load-balance.rb
+++ b/examples/load-balance.rb
@@ -24,7 +24,7 @@ def test
         :name => "#{name}-#{i}",
         :size_gb => 10,
         :zone_name => zone,
-        :source_image => "debian-8-jessie-v20180329"
+        :source_image => "debian-9-stretch-v20180611"
       )
       disk.wait_for { disk.ready? }
     rescue

--- a/examples/metadata.rb
+++ b/examples/metadata.rb
@@ -15,7 +15,7 @@ def test
     :name => name,
     :size_gb => 10,
     :zone_name => "us-central1-f",
-    :source_image => "debian-8-jessie-v20180329"
+    :source_image => "debian-9-stretch-v20180611"
   )
 
   disk.wait_for { disk.ready? }

--- a/examples/network.rb
+++ b/examples/network.rb
@@ -24,7 +24,7 @@ def test
     :name => name,
     :size_gb => 10,
     :zone_name => "us-central1-a",
-    :source_image => "debian-8-jessie-v20180329"
+    :source_image => "debian-9-stretch-v20180611"
   )
 
   disk.wait_for { disk.ready? }

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -27,7 +27,7 @@ module Fog
         #   [
         #     {
         #       :initialize_params => {
-        #         :source_image => "projects/debian-cloud/global/images/family/debian-8"
+        #         :source_image => "projects/debian-cloud/global/images/family/debian-9"
         #       }
         #     }
         #   ]

--- a/lib/fog/compute/google/models/servers.rb
+++ b/lib/fog/compute/google/models/servers.rb
@@ -50,7 +50,7 @@ module Fog
 
           if disks.nil? || disks.empty?
             # create the persistent boot disk
-            source_img = service.images.get_from_family("debian-8")
+            source_img = service.images.get_from_family("debian-9")
             disk_defaults = {
               :name => name,
               :size_gb => 10,

--- a/lib/fog/compute/google/requests/insert_server.rb
+++ b/lib/fog/compute/google/requests/insert_server.rb
@@ -50,7 +50,7 @@ module Fog
         #       :disks => [
         #         {
         #           :initialize_params => {
-        #             :source_image => "projects/debian-cloud/global/images/family/debian-8"
+        #             :source_image => "projects/debian-cloud/global/images/family/debian-9"
         #           }
         #         }
         #       ]

--- a/test/integration/compute/test_addresses.rb
+++ b/test/integration/compute/test_addresses.rb
@@ -29,7 +29,7 @@ class TestAddresses < FogIntegrationTest
                  :boot => true,
                  :auto_delete => true,
                  :initialize_params => {
-                   :source_image => "projects/debian-cloud/global/images/family/debian-8"
+                   :source_image => "projects/debian-cloud/global/images/family/debian-9"
                  }
                ],
                :external_ip => address.address }


### PR DESCRIPTION
Debian 8 has reached its end-of-life as of 18th June 2018 at which point it is in the Long-Term Support stage of the Debian lifecycle (which is best effort). 
Debian 9 “Stretch” is the current stable release of Debian.