### PR TITLE
More compute coverage and some small improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 ### User-facing
 
+#### Added
+
+- \#XXX Add some helper methods to `Fog::Compute::Google::Server`:
+  - `.private_ip_address`
+  - `.stopped?`
+
 #### Changed
 
 - \#383 `Fog::Compute::Google::Address` resources are now created synchronously

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -233,6 +233,14 @@ module Fog
           addresses
         end
 
+        # Helper method that returns the first private ip address of the
+        # instance.
+        #
+        # @return [String]
+        def private_ip_address
+          private_ip_addresses.first
+        end
+
         # Helper method that returns all of server's private ip addresses.
         #
         # @return [Array]

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -179,6 +179,9 @@ module Fog
           "userinfo-email" => ["https://www.googleapis.com/auth/userinfo.email"]
         }.freeze
 
+        # Return the source image of the server's boot disk
+        #
+        # @return [String] image self link
         def image_name
           boot_disk = disks.first
           unless boot_disk.is_a?(Disk)
@@ -189,6 +192,10 @@ module Fog
           boot_disk.source_image.nil? ? nil : boot_disk.source_image
         end
 
+        # Destroy a server.
+        #
+        # @param async [TrueClass] execute the command asynchronously
+        # @return [Fog::Compute::Google::Operation]
         def destroy(async = true)
           requires :name, :zone
 
@@ -200,14 +207,17 @@ module Fog
           operation
         end
 
-        # Helper method that returns first public ip address
-        # for Fog::Compute::Server.ssh default behavior
+        # Helper method that returns first public ip address needed for
+        # Fog::Compute::Server.ssh default behavior.
         #
         # @return [String]
         def public_ip_address
           public_ip_addresses.first
         end
 
+        # Helper method that returns all of server's public ip addresses.
+        #
+        # @return [Array]
         def public_ip_addresses
           addresses = []
           if network_interfaces.respond_to? :flat_map
@@ -223,6 +233,9 @@ module Fog
           addresses
         end
 
+        # Helper method that returns all of server's private ip addresses.
+        #
+        # @return [Array]
         def private_ip_addresses
           addresses = []
           if network_interfaces.respond_to? :map
@@ -231,10 +244,21 @@ module Fog
           addresses
         end
 
+        # Helper method that returns all of server's ip addresses,
+        # both private and public.
+        #
+        # @return [Array]
         def addresses
           private_ip_addresses + public_ip_addresses
         end
 
+        # Attach a disk to a running server
+        #
+        # @param disk [Object, String] disk object or a self-link
+        # @param async [TrueClass] execute the api call asynchronously
+        # @param options [Hash]
+        # @return [Object]
+        # TODO: Figure out what options hash is for here.
         def attach_disk(disk, async = true, options = {})
           requires :identity, :zone
 
@@ -252,6 +276,11 @@ module Fog
           reload
         end
 
+        # Detach disk from a running instance
+        #
+        # @param device_name [Object]
+        # @param async [TrueClass]
+        # @returns [Fog::Compute::Google::Server] server object
         def detach_disk(device_name, async = true)
           requires :identity, :zone
 
@@ -264,6 +293,7 @@ module Fog
         end
 
         # Returns metadata items as a Hash.
+        #
         # @return [Hash<String, String>] items
         def metadata_as_h
           if metadata.nil? || metadata[:items].nil? || metadata[:items].empty?

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -428,16 +428,32 @@ module Fog
           reload
         end
 
+        # Check if instance is provisioning. On staging vs. provisioning difference:
+        # https://cloud.google.com/compute/docs/instances/checking-instance-status
+        #
+        # @return [TrueClass or FalseClass]
         def provisioning?
           status == PROVISIONING
         end
 
-        # Check if instance is Staging. On staging vs. provisioning difference:
+        # Check if instance is staging. On staging vs. provisioning difference:
         # https://cloud.google.com/compute/docs/instances/checking-instance-status
+        #
+        # @return [TrueClass or FalseClass]
         def staging?
           status == STAGING
         end
 
+        # Check if instance is stopped.
+        #
+        # @return [TrueClass or FalseClass]
+        def stopped?
+          status == "TERMINATED"
+        end
+
+        # Check if instance is ready.
+        #
+        # @return [TrueClass or FalseClass]
         def ready?
           status == RUNNING
         end

--- a/test/helpers/integration_test_helper.rb
+++ b/test/helpers/integration_test_helper.rb
@@ -1,5 +1,6 @@
 require "helpers/test_helper"
 require "helpers/test_collection"
+require "pry"
 
 # Use :test credentials in ~/.fog for live integration testing
 # XXX not sure if this will work on Travis CI or not
@@ -13,7 +14,7 @@ TEST_ZONE = "us-central1-f".freeze
 TEST_REGION = "us-central1".freeze
 TEST_SIZE_GB = 10
 TEST_MACHINE_TYPE = "n1-standard-1".freeze
-TEST_IMAGE = "debian-9-stretch-v20180611"
+TEST_IMAGE = "debian-9-stretch-v20180611".freeze
 
 # XXX This depends on a public image in gs://fog-test-bucket; there may be a better way to do this
 # The image was created like so: https://cloud.google.com/compute/docs/images#export_an_image_to_google_cloud_storage

--- a/test/helpers/integration_test_helper.rb
+++ b/test/helpers/integration_test_helper.rb
@@ -13,6 +13,8 @@ TEST_ZONE = "us-central1-f".freeze
 TEST_REGION = "us-central1".freeze
 TEST_SIZE_GB = 10
 TEST_MACHINE_TYPE = "n1-standard-1".freeze
+TEST_IMAGE = "debian-9-stretch-v20180611"
+
 # XXX This depends on a public image in gs://fog-test-bucket; there may be a better way to do this
 # The image was created like so: https://cloud.google.com/compute/docs/images#export_an_image_to_google_cloud_storage
 TEST_RAW_DISK_SOURCE = "http://storage.googleapis.com/fog-test-bucket/fog-test-raw-disk-source.image.tar.gz".freeze

--- a/test/integration/factories/disks_factory.rb
+++ b/test/integration/factories/disks_factory.rb
@@ -12,6 +12,7 @@ class DisksFactory < CollectionFactory
   def params
     { :name => resource_name,
       :zone_name => TEST_ZONE,
+      :source_image => TEST_IMAGE,
       :size_gb => TEST_SIZE_GB }
   end
 end


### PR DESCRIPTION
Server is our most complicated model but it has the worst test coverage.
This is trying to improve it and fix the docs while I'm at it.

Due to the need to instantiate a bunch of servers during the test this slows them down quite a bit...
Looking at ballpark figures - 73 minutes :|

I'll start thinking about speeding things up. I think we can parallelise things more, but that requires careful planning of cleanup (since different API's can trump eachother).