### PR TITLE
Improve Compute coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Added
 
-- \#394 Add some helper methods to `Fog::Compute::Google::Server`:
+- \#394 Add some helper methods to `Fog::Compute::Google::Server` [temikus]
   - `.private_ip_address`
   - `.stopped?`
 
 #### Changed
 
+- \#394 `save/update/destroy` and other operations now wait until they are in a 
+  DONE state, instead of !PENDING. This should be a no-op for users but should 
+  safeguard from issues in the future. [temikus]
 - \#383 `Fog::Compute::Google::Address` resources are now created synchronously
   by default. [temikus]
 
@@ -38,7 +41,14 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
     - Subnetworks
   - Fix compute tests Rake task.
   - Remove old tests and helpers for Disk, Addresses and Networks.
-- \#394 Improve `Server` model test coverage.
+- \#394 Improve `Server` model test coverage + miscellaneous improvements. [temikus]
+  - Add source_image parameter to `DiskFactory` so the Servers factory creates
+    properly running instances.
+  - `CollectionFactory.cleanup` method is now cleaning up resources per-suite
+    instead of using a global prefix.
+  - Add new test formatter improving observability of CI logs.
+  - Add debug logs to test.
+  - Improve doc coverage.
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Added
 
-- \#XXX Add some helper methods to `Fog::Compute::Google::Server`:
+- \#394 Add some helper methods to `Fog::Compute::Google::Server`:
   - `.private_ip_address`
   - `.stopped?`
 
@@ -38,7 +38,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
     - Subnetworks
   - Fix compute tests Rake task.
   - Remove old tests and helpers for Disk, Addresses and Networks.
-  
+- \#394 Improve `Server` model test coverage.
+
 ## 1.6.0
 
 ### User-facing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 ### User-facing
 
+#### Added
+
+- \#XXX Add some helper methods to `Fog::Compute::Google::Server`:
+  - `.private_ip_address`
+  - `.stopped?`
+
 #### Changed
 
 - \#383 `Fog::Compute::Google::Address` resources are now created synchronously

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "retriable"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
+  spec.add_development_dependency "minitest-reporters"
   spec.add_development_dependency "shindo"
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"

--- a/lib/fog/compute/google/models/backend_service.rb
+++ b/lib/fog/compute/google/models/backend_service.rb
@@ -31,7 +31,7 @@ module Fog
 
           data = service.insert_backend_service(name, options)
           operation = Fog::Compute::Google::Operations.new(:service => service).get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/disk.rb
+++ b/lib/fog/compute/google/models/disk.rb
@@ -50,7 +50,7 @@ module Fog
           data = service.insert_disk(name, zone, options[:source_image], options)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name, data.zone)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 
@@ -108,7 +108,7 @@ module Fog
           data = service.create_disk_snapshot(snapshot_name, name, zone_name, snapshot)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name, data.zone)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           service.snapshots.get(snapshot_name)
         end
 

--- a/lib/fog/compute/google/models/firewall.rb
+++ b/lib/fog/compute/google/models/firewall.rb
@@ -55,7 +55,7 @@ module Fog
           data = service.insert_firewall(identity, attributes)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 
@@ -65,7 +65,7 @@ module Fog
           data = service.update_firewall(identity, attributes)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 
@@ -75,7 +75,7 @@ module Fog
           data = service.patch_firewall(identity, diff)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/forwarding_rule.rb
+++ b/lib/fog/compute/google/models/forwarding_rule.rb
@@ -27,7 +27,7 @@ module Fog
           data = service.insert_forwarding_rule(identity, region, attributes)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name, nil, data.region)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/global_address.rb
+++ b/lib/fog/compute/google/models/global_address.rb
@@ -27,7 +27,7 @@ module Fog
           data = service.insert_global_address(identity, attributes)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/global_forwarding_rule.rb
+++ b/lib/fog/compute/google/models/global_forwarding_rule.rb
@@ -27,7 +27,7 @@ module Fog
           data = service.insert_global_forwarding_rule(identity, attributes)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name, nil, data.region)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/http_health_check.rb
+++ b/lib/fog/compute/google/models/http_health_check.rb
@@ -53,7 +53,7 @@ module Fog
           data = service.insert_http_health_check(name, opts)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name, data.zone)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 
@@ -62,7 +62,7 @@ module Fog
           data = service.update_http_health_check(name, opts)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name, data.zone)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/image.rb
+++ b/lib/fog/compute/google/models/image.rb
@@ -68,7 +68,7 @@ module Fog
           data = service.insert_image(name, attributes)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/instance_group_manager.rb
+++ b/lib/fog/compute/google/models/instance_group_manager.rb
@@ -23,7 +23,7 @@ module Fog
           data = service.insert_instance_group_manager(name, zone.split("/")[-1], instance_template, base_instance_name,
           target_size, target_pools, named_ports, description)
           operation = Fog::Compute::Google::Operations.new(:service => service).get(data.name, zone.split("/")[-1])
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/instance_template.rb
+++ b/lib/fog/compute/google/models/instance_template.rb
@@ -30,7 +30,7 @@ module Fog
 
           data = service.insert_instance_template(name, properties, description)
           operation = Fog::Compute::Google::Operations.new(:service => service).get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/route.rb
+++ b/lib/fog/compute/google/models/route.rb
@@ -30,7 +30,7 @@ module Fog
           data = service.insert_route(identity, network, dest_range, priority, attributes)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -233,6 +233,14 @@ module Fog
           addresses
         end
 
+        # Helper method that returns the first private ip address of the
+        # instance.
+        #
+        # @return [String]
+        def private_ip_address
+          private_ip_addresses.first
+        end
+
         # Helper method that returns all of server's private ip addresses.
         #
         # @return [Array]

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -179,6 +179,9 @@ module Fog
           "userinfo-email" => ["https://www.googleapis.com/auth/userinfo.email"]
         }.freeze
 
+        # Return the source image of the server's boot disk
+        #
+        # @return [String] image self link
         def image_name
           boot_disk = disks.first
           unless boot_disk.is_a?(Disk)
@@ -189,6 +192,10 @@ module Fog
           boot_disk.source_image.nil? ? nil : boot_disk.source_image
         end
 
+        # Destroy a server.
+        #
+        # @param async [TrueClass] execute the command asynchronously
+        # @return [Fog::Compute::Google::Operation]
         def destroy(async = true)
           requires :name, :zone
 
@@ -200,14 +207,17 @@ module Fog
           operation
         end
 
-        # Helper method that returns first public ip address
-        # for Fog::Compute::Server.ssh default behavior
+        # Helper method that returns first public ip address needed for
+        # Fog::Compute::Server.ssh default behavior.
         #
         # @return [String]
         def public_ip_address
           public_ip_addresses.first
         end
 
+        # Helper method that returns all of server's public ip addresses.
+        #
+        # @return [Array]
         def public_ip_addresses
           addresses = []
           if network_interfaces.respond_to? :flat_map
@@ -223,6 +233,9 @@ module Fog
           addresses
         end
 
+        # Helper method that returns all of server's private ip addresses.
+        #
+        # @return [Array]
         def private_ip_addresses
           addresses = []
           if network_interfaces.respond_to? :map
@@ -231,10 +244,21 @@ module Fog
           addresses
         end
 
+        # Helper method that returns all of server's ip addresses,
+        # both private and public.
+        #
+        # @return [Array]
         def addresses
           private_ip_addresses + public_ip_addresses
         end
 
+        # Attach a disk to a running server
+        #
+        # @param disk [Object, String] disk object or a self-link
+        # @param async [TrueClass] execute the api call asynchronously
+        # @param options [Hash]
+        # @return [Object]
+        # TODO: Figure out what options hash is for here.
         def attach_disk(disk, async = true, options = {})
           requires :identity, :zone
 
@@ -252,6 +276,11 @@ module Fog
           reload
         end
 
+        # Detach disk from a running instance
+        #
+        # @param device_name [Object]
+        # @param async [TrueClass]
+        # @returns [Fog::Compute::Google::Server] server object
         def detach_disk(device_name, async = true)
           requires :identity, :zone
 
@@ -264,6 +293,7 @@ module Fog
         end
 
         # Returns metadata items as a Hash.
+        #
         # @return [Hash<String, String>] items
         def metadata_as_h
           if metadata.nil? || metadata[:items].nil? || metadata[:items].empty?

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -428,16 +428,32 @@ module Fog
           reload
         end
 
+        # Check if instance is provisioning. On staging vs. provisioning difference:
+        # https://cloud.google.com/compute/docs/instances/checking-instance-status
+        #
+        # @return [TrueClass or FalseClass]
         def provisioning?
           status == PROVISIONING
         end
 
-        # Check if instance is Staging. On staging vs. provisioning difference:
+        # Check if instance is staging. On staging vs. provisioning difference:
         # https://cloud.google.com/compute/docs/instances/checking-instance-status
+        #
+        # @return [TrueClass or FalseClass]
         def staging?
           status == STAGING
         end
 
+        # Check if instance is stopped.
+        #
+        # @return [TrueClass or FalseClass]
+        def stopped?
+          status == "TERMINATED"
+        end
+
+        # Check if instance is ready.
+        #
+        # @return [TrueClass or FalseClass]
         def ready?
           status == RUNNING
         end

--- a/lib/fog/compute/google/models/subnetwork.rb
+++ b/lib/fog/compute/google/models/subnetwork.rb
@@ -26,7 +26,7 @@ module Fog
           data = service.insert_subnetwork(identity, region, network, ip_cidr_range, attributes)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name, nil, data.region)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/target_http_proxy.rb
+++ b/lib/fog/compute/google/models/target_http_proxy.rb
@@ -18,7 +18,7 @@ module Fog
           )
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/target_instance.rb
+++ b/lib/fog/compute/google/models/target_instance.rb
@@ -26,7 +26,7 @@ module Fog
           data = service.insert_target_instance(identity, zone, options)
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name, data.zone)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/target_pool.rb
+++ b/lib/fog/compute/google/models/target_pool.rb
@@ -25,7 +25,7 @@ module Fog
           operation = Fog::Compute::Google::Operations
                       .new(:service => service)
                       .get(data.name, nil, data.region)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/compute/google/models/url_map.rb
+++ b/lib/fog/compute/google/models/url_map.rb
@@ -36,7 +36,7 @@ module Fog
           end
           operation = Fog::Compute::Google::Operations.new(:service => service)
                                                       .get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/dns/google/models/record.rb
+++ b/lib/fog/dns/google/models/record.rb
@@ -72,7 +72,7 @@ module Fog
           change = Fog::DNS::Google::Changes
                    .new(:service => service, :zone => zone)
                    .get(data.id)
-          change.wait_for { !pending? }
+          change.wait_for { ready? }
           self
         end
 

--- a/lib/fog/google/models/sql/instance.rb
+++ b/lib/fog/google/models/sql/instance.rb
@@ -318,7 +318,7 @@ module Fog
 
           data = service.update_instance(identity, settings_version, tier, settings)
           operation = Fog::Google::SQL::Operations.new(:service => service).get(data.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
           reload
         end
 

--- a/lib/fog/google/models/sql/user.rb
+++ b/lib/fog/google/models/sql/user.rb
@@ -42,7 +42,7 @@ module Fog
           end
 
           operation = Fog::Google::SQL::Operations.new(:service => service).get(resp.name)
-          operation.wait_for { !pending? }
+          operation.wait_for { ready? }
         end
       end
     end

--- a/test/helpers/integration_test_helper.rb
+++ b/test/helpers/integration_test_helper.rb
@@ -5,6 +5,9 @@ require "helpers/test_collection"
 # XXX not sure if this will work on Travis CI or not
 Fog.credential = :test
 
+# Enable test debugging, providing additional information in some methods
+DEBUG = ENV['DEBUG'] || false
+
 # Helpers
 
 TEST_PROJECT = Fog.credentials[:google_project]

--- a/test/helpers/integration_test_helper.rb
+++ b/test/helpers/integration_test_helper.rb
@@ -13,6 +13,8 @@ TEST_ZONE = "us-central1-f".freeze
 TEST_REGION = "us-central1".freeze
 TEST_SIZE_GB = 10
 TEST_MACHINE_TYPE = "n1-standard-1".freeze
+TEST_IMAGE = "debian-9-stretch-v20180611"
+
 # XXX This depends on a public image in gs://fog-test-bucket; there may be a better way to do this
 # The image was created like so: https://cloud.google.com/compute/docs/images#export_an_image_to_google_cloud_storage
 TEST_RAW_DISK_SOURCE = "http://storage.googleapis.com/fog-test-bucket/fog-test-raw-disk-source.image.tar.gz".freeze

--- a/test/helpers/integration_test_helper.rb
+++ b/test/helpers/integration_test_helper.rb
@@ -6,7 +6,7 @@ require "helpers/test_collection"
 Fog.credential = :test
 
 # Enable test debugging, providing additional information in some methods
-DEBUG = ENV['FOG_TEST_DEBUG'] || true
+DEBUG = ENV['FOG_TEST_DEBUG'] || false
 
 # Helpers
 

--- a/test/helpers/integration_test_helper.rb
+++ b/test/helpers/integration_test_helper.rb
@@ -6,7 +6,7 @@ require "helpers/test_collection"
 Fog.credential = :test
 
 # Enable test debugging, providing additional information in some methods
-DEBUG = ENV['DEBUG'] || false
+DEBUG = ENV['FOG_TEST_DEBUG'] || true
 
 # Helpers
 

--- a/test/helpers/integration_test_helper.rb
+++ b/test/helpers/integration_test_helper.rb
@@ -13,7 +13,7 @@ TEST_ZONE = "us-central1-f".freeze
 TEST_REGION = "us-central1".freeze
 TEST_SIZE_GB = 10
 TEST_MACHINE_TYPE = "n1-standard-1".freeze
-TEST_IMAGE = "debian-9-stretch-v20180611"
+TEST_IMAGE = "debian-9-stretch-v20180611".freeze
 
 # XXX This depends on a public image in gs://fog-test-bucket; there may be a better way to do this
 # The image was created like so: https://cloud.google.com/compute/docs/images#export_an_image_to_google_cloud_storage

--- a/test/helpers/test_helper.rb
+++ b/test/helpers/test_helper.rb
@@ -16,5 +16,8 @@ end
 # See https://github.com/seattlerb/minitest/#install
 gem "minitest"
 require "minitest/autorun"
+# Custom formatters
+require "minitest/reporters"
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
 require File.join(File.dirname(__FILE__), "../../lib/fog/google")

--- a/test/integration/factories/collection_factory.rb
+++ b/test/integration/factories/collection_factory.rb
@@ -12,7 +12,7 @@ class CollectionFactory
   # @param async [FalseClass or TrueClass] perform resource destruction asynchronously
   def cleanup(async = false)
     suit_name = @example.gsub(/\W/, "").tr("_", "-").downcase.split('-')[0]
-    resources = @subject.all.select { |resource| resource.name.match? /#{PREFIX}-[0-9]*-#{suit_name}/ }
+    resources = @subject.all.select { |resource| resource.name.match /#{PREFIX}-[0-9]*-#{suit_name}/ }
     if DEBUG
       p "Cleanup invoked in #{self} for example: #{@example}"
       p "Resources to be deleted: #{resources.map { |r| r.name }}"

--- a/test/integration/factories/collection_factory.rb
+++ b/test/integration/factories/collection_factory.rb
@@ -7,8 +7,12 @@ class CollectionFactory
     @resource_counter = 0
   end
 
-  def cleanup(async = true)
-    resources = @subject.all.select { |resource| resource.name.start_with? PREFIX }
+  # Cleans up all objects created by the factory in the current test suite.
+  #
+  # @param async [FalseClass or TrueClass] perform resource destruction asynchronously
+  def cleanup(async = false)
+    suit_name = @example.gsub(/\W/, "").tr("_", "-").downcase.split('-')[0]
+    resources = @subject.all.select { |resource| resource.name.match? /#{PREFIX}-[0-9]*-#{suit_name}/ }
     if DEBUG
       p "Cleanup invoked in #{self} for example: #{@example}"
       p "Resources to be deleted: #{resources.map { |r| r.name }}"
@@ -20,7 +24,7 @@ class CollectionFactory
 
   # Creates a collection object instance e.g. Fog::Compute::Google::Server
   #
-  # @param [Hash] custom_params - override factory creation parameters or provide
+  # @param custom_params [Hash] override factory creation parameters or provide
   #   additional ones. Useful in tests where you need to create a slightly different
   #   resource than the default one but still want to take advantage of the factory's
   #   cleanup methods, etc.
@@ -29,7 +33,7 @@ class CollectionFactory
   #   @factory = ServersFactory.new(namespaced_name)
   #   server = @factory.create(:machine_type => "f1-micro")
   #
-  # @return [Object] - collection object instance
+  # @return [Object] collection object instance
   def create(custom_params = {})
     @subject.create(params.merge(custom_params))
   end

--- a/test/integration/factories/collection_factory.rb
+++ b/test/integration/factories/collection_factory.rb
@@ -9,6 +9,11 @@ class CollectionFactory
 
   def cleanup(async = false)
     resources = @subject.all.select { |resource| resource.name.start_with? PREFIX }
+    if DEBUG
+      p "Cleanup invoked in #{self} for example: #{@example}"
+      p "Resources to be deleted: #{resources.map { |r| r.name }}"
+      p "All subject resources: #{@subject.all.map { |s| s.name }}"
+    end
     resources.each { |r| r.destroy(async) }
     resources.each { |r| Fog.wait_for { !@subject.all.map(&:identity).include? r.identity } }
   end

--- a/test/integration/factories/collection_factory.rb
+++ b/test/integration/factories/collection_factory.rb
@@ -7,7 +7,7 @@ class CollectionFactory
     @resource_counter = 0
   end
 
-  def cleanup(async = false)
+  def cleanup(async = true)
     resources = @subject.all.select { |resource| resource.name.start_with? PREFIX }
     if DEBUG
       p "Cleanup invoked in #{self} for example: #{@example}"

--- a/test/integration/factories/disks_factory.rb
+++ b/test/integration/factories/disks_factory.rb
@@ -12,6 +12,7 @@ class DisksFactory < CollectionFactory
   def params
     { :name => resource_name,
       :zone_name => TEST_ZONE,
+      :source_image => TEST_IMAGE,
       :size_gb => TEST_SIZE_GB }
   end
 end


### PR DESCRIPTION
Server is our most complicated model but it has the worst test coverage.
This is trying to improve it and fix the docs while I'm at it.

Due to the need to instantiate a bunch of servers during the test this slows them down quite a bit...
Looking at ballpark figures - 73 minutes :|

I'll start thinking about speeding things up. I think we can parallelise things more, but that requires careful planning of cleanup (since different API's can trump eachother).