### PR TITLE
apply given API service client options

### DIFF
--- a/lib/fog/compute/google/real.rb
+++ b/lib/fog/compute/google/real.rb
@@ -13,6 +13,8 @@ module Fog
 
           initialize_google_client(options)
           @compute = ::Google::Apis::ComputeV1::ComputeService.new
+          apply_client_options(@compute, options)
+
           @extra_global_projects = options[:google_extra_global_projects] || []
         end
       end

--- a/lib/fog/dns/google/real.rb
+++ b/lib/fog/dns/google/real.rb
@@ -11,6 +11,7 @@ module Fog
           options[:google_api_scope_url] = GOOGLE_DNS_API_SCOPE_URLS.join(" ")
           initialize_google_client(options)
           @dns = ::Google::Apis::DnsV1::DnsService.new
+          apply_client_options(@dns, options)
         end
       end
     end

--- a/lib/fog/google/monitoring/real.rb
+++ b/lib/fog/google/monitoring/real.rb
@@ -12,6 +12,7 @@ module Fog
 
           initialize_google_client(options)
           @monitoring = ::Google::Apis::MonitoringV3::MonitoringService.new
+          apply_client_options(@monitoring, options)
         end
       end
     end

--- a/lib/fog/google/pubsub/real.rb
+++ b/lib/fog/google/pubsub/real.rb
@@ -13,6 +13,7 @@ module Fog
 
           @client = initialize_google_client(options)
           @pubsub = ::Google::Apis::PubsubV1::PubsubService.new
+          apply_client_options(@pubsub, options)
         end
       end
     end

--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -30,7 +30,7 @@ module Fog
       # @option options [String] :app_name The app name to set in the user agent
       # @option options [String] :app_version The app version to set in the user agent
       # @option options [Google::APIClient] :google_client Existing Google API Client
-      # @option options [Hash] :google_client_options A hash to send adition options to Google API Client
+      # @option options [Hash] :google_client_options A hash to send additional options to Google API Client
       # @return [Google::APIClient] Google API Client
       # @raises [ArgumentError] If there is any missing argument
       def initialize_google_client(options)
@@ -117,6 +117,20 @@ module Fog
 
         ::Google::Apis::RequestOptions.default.authorization = auth
         auth
+      end
+
+      ##
+      # Applies given options to the client instance
+      #
+      # @param [Google::Apis::Core::BaseService] service API service client instance
+      # @param [Hash] google_client_options Service client options to apply
+      # @param [Hash] _ignored Rest of the options (for convenience, ignored)
+      # @return [void]
+      def apply_client_options(service, google_client_options: nil, **_ignored)
+        return if google_client_options.nil? || google_client_options.empty?
+        (service.client_options.members & google_client_options.keys).each do |option|
+          service.client_options[option] = google_client_options[option]
+        end
       end
 
       ##

--- a/lib/fog/google/sql/real.rb
+++ b/lib/fog/google/sql/real.rb
@@ -13,6 +13,7 @@ module Fog
 
           initialize_google_client(options)
           @sql = ::Google::Apis::SqladminV1beta4::SQLAdminService.new
+          apply_client_options(@sql, options)
         end
       end
     end

--- a/lib/fog/storage/google_json/real.rb
+++ b/lib/fog/storage/google_json/real.rb
@@ -15,6 +15,8 @@ module Fog
 
           @client = initialize_google_client(options)
           @storage_json = ::Google::Apis::StorageV1::StorageService.new
+          apply_client_options(@storage_json, options)
+
           @storage_json.client_options.open_timeout_sec = options[:open_timeout_sec] if options[:open_timeout_sec]
           @storage_json.client_options.read_timeout_sec = options[:read_timeout_sec] if options[:read_timeout_sec]
           @storage_json.client_options.send_timeout_sec = options[:send_timeout_sec] if options[:send_timeout_sec]


### PR DESCRIPTION
That feature was broken with Google's gem update and
 this PR: https://github.com/fog/fog-google/commit/5ec9a15e1a0645e5ce9673c71468975db4926efb#diff-c6b2ed334d1938d66b4e168f255abbb7L140

Now it's back.