### PR TITLE
Fix core dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.8.0
+
+### User-facing
+
+#### Fixed
+
+- \#419 Locked down fog upstream dependencies to alleviate deprecation warnings
+  until they can be properly dealt with.
+
 ## 1.7.1
 
 ### User-facing

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
   # As of 0.1.1
   spec.required_ruby_version = "~> 2.0"
 
-  spec.add_dependency "fog-core"
-  spec.add_dependency "fog-json"
-  spec.add_dependency "fog-xml"
+  # Locked until https://github.com/fog/fog-google/issues/417 is resolved
+  spec.add_dependency "fog-core", ">= 2.0", "<= 2.1.0"
+  spec.add_dependency "fog-json", "~> 1.2.0"
+  spec.add_dependency "fog-xml", "~> 0.1.0"
 
   # Hard Requirement as of 1.0
   spec.add_dependency "google-api-client", "~> 0.23.0"

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -28,8 +28,6 @@ Gem::Specification.new do |spec|
   # Hard Requirement as of 1.0
   spec.add_dependency "google-api-client", "~> 0.23.0"
   
-  spec.add_development_dependency "mime-types"
-
   # Debugger
   spec.add_development_dependency "pry"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This should alleviate #417 until we can properly upgrade all the tests, etc.

Additionally, locks the major versions of other upstream deps.