### PR TITLE
Release 1.8.1 🛠

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.8.1
+
+### User-facing
+
+#### Fixed
+
+- \#428 Relax fog-core lower version constraint for ManageIQ [temikus]
+
 ## 1.8.0
 
 ### User-facing

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.0"
 
   # Locked until https://github.com/fog/fog-google/issues/417 is resolved
-  spec.add_dependency "fog-core", ">= 2.0", "<= 2.1.0"
+  spec.add_dependency "fog-core", "<= 2.1.0"
   spec.add_dependency "fog-json", "~> 1.2.0"
   spec.add_dependency "fog-xml", "~> 0.1.0"
 

--- a/lib/fog/google/version.rb
+++ b/lib/fog/google/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module Google
-    VERSION = "1.8.0".freeze
+    VERSION = "1.8.1".freeze
   end
 end


### PR DESCRIPTION
This is a tiny patch release to relax fog-core constraint and keep compatibility with ManageIQ.

Ref: https://github.com/ManageIQ/manageiq-providers-google/pull/73