### PR TITLE
Allow the api to close Tempfiles inline

### DIFF
--- a/lib/fog/storage/google_json/requests/get_object.rb
+++ b/lib/fog/storage/google_json/requests/get_object.rb
@@ -68,6 +68,8 @@ module Fog
           end
 
           object
+        ensure
+          buf.close! rescue nil
         end
       end
 


### PR DESCRIPTION
Allows the the gem to clean up temporary files at execution time rather than relying on the Garbage Collector to clean up or other parts of the MRI calling the object space finalize methods.