### PR TITLE
Support non-boot disk

### DIFF
--- a/lib/fog/compute/google/models/disk.rb
+++ b/lib/fog/compute/google/models/disk.rb
@@ -74,9 +74,13 @@ module Fog
         end
 
         def get_as_boot_disk(writable = true, auto_delete = false)
+          get_as_disk(writable, true, auto_delete)
+        end
+
+        def get_as_disk(writable = true, boot = false, auto_delete = false)
           {
             :auto_delete => auto_delete,
-            :boot => true,
+            :boot => boot,
             :source => self_link,
             :mode =>  writable ? "READ_WRITE" : "READ_ONLY",
             :type => "PERSISTENT"


### PR DESCRIPTION
Based on the discuss here [vagrant-google](https://github.com/mitchellh/vagrant-google/issues/102#issuecomment-443035070), to allow mounting additional (non-boot) disks, we need to make some change accordingly.

Could you take a look at this patch? @Temikus 
