### PR TITLE
feat: Allow Google Application Default Credentials

### DIFF
--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -78,6 +78,11 @@ module Fog
         ::Google::Apis::ClientOptions.default.application_name = application_name
         ::Google::Apis::ClientOptions.default.application_version = Fog::Google::VERSION
 
+        if ENV["DEBUG"]
+          ::Google::Apis.logger = ::Logger.new(::STDERR)
+          ::Google::Apis.logger.level = ::Logger::DEBUG
+        end
+
         auth = nil
         if options[:google_json_key_location] || options[:google_json_key_string]
           if options[:google_json_key_location]
@@ -97,11 +102,6 @@ module Fog
             raise ArgumentError.new("Missing required arguments: google_client_email")
           end
 
-          if ENV["DEBUG"]
-            ::Google::Apis.logger = ::Logger.new(::STDERR)
-            ::Google::Apis.logger.level = ::Logger::DEBUG
-          end
-
           auth = ::Google::Auth::ServiceAccountCredentials.make_creds(
             :json_key_io => StringIO.new(json_key_hash.to_json),
             :scope => options[:google_api_scope_url]
@@ -109,10 +109,17 @@ module Fog
         elsif options[:google_auth]
           auth = options[:google_auth]
         else
-          raise ArgumentError.new(
-            "Missing required arguments: google_json_key_location, "\
-            "google_json_key_string or google_auth"
-          )
+          # fall back to Application Default Credentials before erroring
+          begin
+            auth = ::Google::Auth::DefaultCredentials.from_well_known_path(
+              options[:google_api_scope_url]
+            )
+          rescue StandardError
+            raise ArgumentError.new(
+              "Application Default Credentials not found; Missing required " \
+              "arguments: google_json_key_location, google_json_key_string or google_auth"
+            )
+          end
         end
 
         ::Google::Apis::RequestOptions.default.authorization = auth

--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -110,14 +110,13 @@ module Fog
           auth = options[:google_auth]
         else
           # fall back to Application Default Credentials before erroring
-          begin
-            auth = ::Google::Auth::DefaultCredentials.from_well_known_path(
-              options[:google_api_scope_url]
-            )
-          rescue StandardError
+          auth = ::Google::Auth.get_application_default(
+            options[:google_api_scope_url]
+          )
+          if auth.nil?
             raise ArgumentError.new(
-              "Application Default Credentials not found; Missing required " \
-              "arguments: google_json_key_location, google_json_key_string or google_auth"
+              "Missing required arguments: google_json_key_location, " \
+              "google_json_key_string or google_auth"
             )
           end
         end


### PR DESCRIPTION
Previously, `fog-google` implicitly required a service account to
authenticate against the Google Cloud Platform APIs.
This change allows the use of Application Default Credentials so that
end users can authenticate without a service account for development,
testing, and one-off interactions.
This change does not check any of the different environment variables
that Google documents for its client libraries and instead reads a
well-known file path for ADCs.