### PR TITLE
WIP Better credential workflow

### DIFF
--- a/.fog.example
+++ b/.fog.example
@@ -16,8 +16,7 @@
 my_google_credentials:
     google_project: my-project-id
     google_json_key_location: /path/to/my-project-xxxxxxxxxxxx.json
-    # You can also provide service account credentials with `google_json_key_string` or 
-    # with `google_key_location` and `google_key_string` for P12 private keys.
+    # You can also provide service account credentials with `google_json_key_string`
     # If so, uncomment the two following lines.
     # HMAC credentials follow a similar format:
 	#google_storage_access_key_id: GOOGXXXXXXXXXXXXXXXX

--- a/.fog.example
+++ b/.fog.example
@@ -15,7 +15,6 @@
 # START GOOGLE CONFIG
 my_google_credentials:
     google_project: my-project-id
-    google_client_email: xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@developer.gserviceaccount.com
     google_json_key_location: /path/to/my-project-xxxxxxxxxxxx.json
     # You can also provide service account credentials with `google_json_key_string` or 
     # with `google_key_location` and `google_key_string` for P12 private keys.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,6 @@ make sure you have a `:test` credential in `~/.fog`, something like:
 ```
 test:
   google_project: my-project
-  google_client_email: xxxxxxxxxxxxx-xxxxxxxxxxxxx@developer.gserviceaccount.com
   google_json_key_location: /path/to/my-project-xxxxxxxxxxxxx.json
 ```
 

--- a/ci/credentials.yml.template
+++ b/ci/credentials.yml.template
@@ -3,8 +3,6 @@
 codecov_token:
 # Google Cloud Platform project to run under
 google_project:
-# Google Compute Engine Service Account email
-google_client_email:
 # Google Compute Engine Service Account JSON
 google_json_key_data: |
   {

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -16,7 +16,6 @@ jobs:
           codecov_token: {{codecov_token}}
           google_project: {{google_project}}
           google_json_key_data: {{google_json_key_data}}
-          google_client_email: {{google_client_email}}
         on_failure:
           put: pull-request
           params:
@@ -40,7 +39,6 @@ jobs:
           codecov_token: {{codecov_token}}
           google_project: {{google_project}}
           google_json_key_data: {{google_json_key_data}}
-          google_client_email: {{google_client_email}}
         on_failure:
           put: pull-request
           params:
@@ -64,7 +62,6 @@ jobs:
           codecov_token: {{codecov_token}}
           google_project: {{google_project}}
           google_json_key_data: {{google_json_key_data}}
-          google_client_email: {{google_client_email}}
         on_failure:
           put: pull-request
           params:
@@ -88,7 +85,6 @@ jobs:
           codecov_token: {{codecov_token}}
           google_project: {{google_project}}
           google_json_key_data: {{google_json_key_data}}
-          google_client_email: {{google_client_email}}
         on_failure:
           put: pull-request
           params:
@@ -112,7 +108,6 @@ jobs:
           codecov_token: {{codecov_token}}
           google_project: {{google_project}}
           google_json_key_data: {{google_json_key_data}}
-          google_client_email: {{google_client_email}}
         on_failure:
           put: pull-request
           params:
@@ -136,7 +131,6 @@ jobs:
           codecov_token: {{codecov_token}}
           google_project: {{google_project}}
           google_json_key_data: {{google_json_key_data}}
-          google_client_email: {{google_client_email}}
         on_failure:
           put: pull-request
           params:
@@ -160,7 +154,6 @@ jobs:
           codecov_token: {{codecov_token}}
           google_project: {{google_project}}
           google_json_key_data: {{google_json_key_data}}
-          google_client_email: {{google_client_email}}
         on_failure:
           put: pull-request
           params:
@@ -184,7 +177,6 @@ jobs:
           codecov_token: {{codecov_token}}
           google_project: {{google_project}}
           google_json_key_data: {{google_json_key_data}}
-          google_client_email: {{google_client_email}}
         on_failure:
           put: pull-request
           params:
@@ -208,7 +200,6 @@ jobs:
           codecov_token: {{codecov_token}}
           google_project: {{google_project}}
           google_json_key_data: {{google_json_key_data}}
-          google_client_email: {{google_client_email}}
         on_failure:
           put: pull-request
           params:

--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -13,7 +13,6 @@ source ci/tasks/utils.sh
 popd > /dev/null
 
 check_param google_project
-check_param google_client_email
 check_param google_json_key_data
 check_param rake_task
 check_param codecov_token
@@ -23,7 +22,6 @@ echo $google_json_key_data > `pwd`/service_account_key.json
 cat >~/.fog <<EOL
 test:
   google_project: ${google_project}
-  google_client_email: ${google_client_email}
   google_json_key_location: `pwd`/service_account_key.json
 EOL
 

--- a/ci/tasks/run-int.yml
+++ b/ci/tasks/run-int.yml
@@ -12,6 +12,5 @@ params:
   rake_task: replace-me
   codecov_token: replace-me
   google_project: replace-me
-  google_client_email: replace-me
   google_json_key_data: |
     replace-me

--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -10,7 +10,6 @@ module Fog
         :app_version,
         :google_auth,
         :google_client,
-        :google_client_email,
         :google_client_options,
         :google_extra_global_projects,
         :google_key_location,

--- a/lib/fog/dns/google.rb
+++ b/lib/fog/dns/google.rb
@@ -10,7 +10,6 @@ module Fog
         :app_version,
         :google_auth,
         :google_client,
-        :google_client_email,
         :google_client_options,
         :google_key_location,
         :google_key_string,

--- a/lib/fog/google/monitoring.rb
+++ b/lib/fog/google/monitoring.rb
@@ -9,7 +9,6 @@ module Fog
         :app_name,
         :app_version,
         :google_client,
-        :google_client_email,
         :google_client_options,
         :google_key_location,
         :google_key_string,

--- a/lib/fog/google/pubsub.rb
+++ b/lib/fog/google/pubsub.rb
@@ -10,7 +10,6 @@ module Fog
         :app_version,
         :google_auth,
         :google_client,
-        :google_client_email,
         :google_client_options,
         :google_json_key_location,
         :google_json_key_string,

--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -168,20 +168,20 @@ module Fog
       # @return [Google::Auth::DefaultCredentials] - google auth object
       def process_fallback_auth(options)
         Fog::Logger.warning(
-            "Didn't detect any client auth settings, " \
-              "trying to fall back to application default credentials..."
+          "Didn't detect any client auth settings, " \
+          "trying to fall back to application default credentials..."
         )
         begin
           return process_application_default_auth(options)
         rescue
           raise Fog::Errors::Error.new(
-              "Fallback auth failed, could not configure authentication for Fog client.\n" \
-                "Check your auth options, must be one of:\n" \
-                "- :google_json_key_location,\n" \
-                "- :google_json_key_string,\n" \
-                "- :google_auth,\n" \
-                "- :google_application_default,\n" \
-                "If credentials are valid - please, file a bug to fog-google." \
+            "Fallback auth failed, could not configure authentication for Fog client.\n" \
+              "Check your auth options, must be one of:\n" \
+              "- :google_json_key_location,\n" \
+              "- :google_json_key_string,\n" \
+              "- :google_auth,\n" \
+              "- :google_application_default,\n" \
+              "If credentials are valid - please, file a bug to fog-google." \
           )
         end
       end
@@ -200,8 +200,8 @@ module Fog
         validate_json_credentials(json_key)
 
         ::Google::Auth::ServiceAccountCredentials.make_creds(
-            :json_key_io => StringIO.new(json_key),
-            :scope => options[:google_api_scope_url]
+          :json_key_io => StringIO.new(json_key),
+          :scope => options[:google_api_scope_url]
         )
       end
 

--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -49,30 +49,7 @@ module Fog
           raise error
         end
 
-        # Users can no longer provide their own clients due to rewrite of auth
-        # in https://github.com/google/google-api-ruby-client/ version 0.9.
-        if options[:google_client]
-          raise ArgumentError.new("Deprecated argument no longer works: google_client")
-        end
-
-        # They can also no longer use pkcs12 files, because Google's new auth
-        # library doesn't support them either.
-        if options[:google_key_location]
-          raise ArgumentError.new("Deprecated argument no longer works: google_key_location")
-        end
-        if options[:google_key_string]
-          raise ArgumentError.new("Deprecated argument no longer works: google_key_string")
-        end
-
-
-        if options[:google_client_email]
-          Fog::Logger.warning("Deprecated argument no longer required: google_client_email")
-        end
-
-        # Validate required arguments
-        unless options[:google_api_scope_url]
-          raise ArgumentError.new("Missing required arguments: google_api_scope_url")
-        end
+        validate_client_options(options)
 
         application_name = "fog"
         unless options[:app_name].nil?
@@ -88,36 +65,31 @@ module Fog
         end
 
         auth = nil
+
         if options[:google_json_key_location] || options[:google_json_key_string]
-          if options[:google_json_key_location]
-            json_key_location = File.expand_path(options[:google_json_key_location])
-            json_key = File.open(json_key_location, "r", &:read)
-          else
-            json_key = options[:google_json_key_string]
-          end
-
-          json_key_hash = Fog::JSON.decode(json_key)
-          unless json_key_hash.key?("client_email") || json_key_hash.key?("private_key")
-            raise ArgumentError.new("Invalid Google JSON key")
-          end
-
-          auth = ::Google::Auth::ServiceAccountCredentials.make_creds(
-            :json_key_io => StringIO.new(json_key_hash.to_json),
-            :scope => options[:google_api_scope_url]
-          )
+          auth = process_key_auth(options)
         elsif options[:google_auth]
           auth = options[:google_auth]
+        elsif options[:application_default]
+          auth = process_application_default_auth(options)
         else
-          # fall back to Application Default Credentials before erroring
-          auth = ::Google::Auth.get_application_default(
-            options[:google_api_scope_url]
+          Fog::Logger.warning(
+              "Didn't detect any explicit auth settings, " \
+              "trying to use application default credentials."
           )
-          if auth.nil?
-            raise ArgumentError.new(
-              "Missing required arguments: google_json_key_location, " \
-              "google_json_key_string or google_auth"
-            )
-          end
+          auth = process_application_default_auth(options)
+        end
+
+        if auth.nil?
+          raise Fog::Errors::Error.new(
+              "Failed to configure authentication for Fog client.\n" \
+                "Check your auth options, must be one of:\n" \
+                "- :google_json_key_location,\n" \
+                "- :google_json_key_string,\n" \
+                "- :google_auth,\n" \
+                "- :application_default,\n" \
+                "If credentials are valid - please, file a bug to fog-google." \
+          )
         end
 
         ::Google::Apis::RequestOptions.default.authorization = auth
@@ -192,6 +164,82 @@ module Fog
         end
 
         response
+      end
+
+      private
+
+      # Helper method to process application default authentication
+      #
+      # @param [Hash]  options - client options hash
+      # @return [Google::Auth::DefaultCredentials] - google auth object
+      def process_application_default_auth(options)
+        begin
+          return ::Google::Auth.get_application_default(options[:google_api_scope_url])
+        rescue RuntimeError => e
+          # Google API Client returns runtime error if it cannot load up creds
+          nil
+        end
+      end
+
+      # Helper method to process key authentication
+      #
+      # @param [Hash]  options - client options hash
+      # @return [Google::Auth::ServiceAccountCredentials] - google auth object
+      def process_key_auth(options)
+        if options[:google_json_key_location]
+          json_key = File.read(File.expand_path(options[:google_json_key_location]))
+        elsif options[:google_json_key_string]
+          json_key = options[:google_json_key_string]
+        end
+
+        validate_json_credentials(json_key)
+
+        ::Google::Auth::ServiceAccountCredentials.make_creds(
+            :json_key_io => StringIO.new(json_key),
+            :scope => options[:google_api_scope_url]
+        )
+      end
+
+      # Helper method to sort out deprecated and missing auth options
+      #
+      # @param [Hash]  options - client options hash
+      def validate_client_options(options)
+        # Users can no longer provide their own clients due to rewrite of auth
+        # in https://github.com/google/google-api-ruby-client/ version 0.9.
+        if options[:google_client]
+          raise ArgumentError.new("Deprecated argument no longer works: google_client")
+        end
+
+        # They can also no longer use pkcs12 files, because Google's new auth
+        # library doesn't support them either.
+        if options[:google_key_location]
+          raise ArgumentError.new("Deprecated auth method no longer works: google_key_location")
+        end
+        if options[:google_key_string]
+          raise ArgumentError.new("Deprecated auth method no longer works: google_key_string")
+        end
+
+        # Google client email option is no longer needed
+        if options[:google_client_email]
+          Fog::Logger.deprecation("Argument no longer needed for auth: google_client_email")
+        end
+
+        # Validate required arguments
+        unless options[:google_api_scope_url]
+          raise ArgumentError.new("Missing required arguments: google_api_scope_url")
+        end
+      end
+
+      # Helper method to checks whether the necessary fields are present in
+      # JSON key credentials
+      #
+      # @param [String]  json_key - Google json auth key string
+      def validate_json_credentials(json_key)
+        json_key_hash = Fog::JSON.decode(json_key)
+
+        unless json_key_hash.key?("client_email") || json_key_hash.key?("private_key")
+          raise ArgumentError.new("Invalid Google JSON key")
+        end
       end
     end
   end

--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -22,14 +22,11 @@ module Fog
       # @param [Hash] options Google API options
       # @option options [Bool]   :google_application_default Explicitly use application default credentials
       # @option options [Google::Auth|Signet] :google_auth Manually created authorization to use
-      # @option options [String] :google_key_location The location of a pkcs12 key file
-      # @option options [String] :google_key_string The content of the pkcs12 key file
       # @option options [String] :google_json_key_location The location of a JSON key file
       # @option options [String] :google_json_key_string The content of the JSON key file
       # @option options [String] :google_api_scope_url The access scope URLs
       # @option options [String] :app_name The app name to set in the user agent
       # @option options [String] :app_version The app version to set in the user agent
-      # @option options [Google::APIClient] :google_client Existing Google API Client
       # @option options [Hash] :google_client_options A hash to send additional options to Google API Client
       # @return [Google::APIClient] Google API Client
       # @raises [ArgumentError] If there is any missing argument

--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -21,7 +21,6 @@ module Fog
       #
       # @param [Hash] options Google API options
       # @option options [Google::Auth|Signet] :google_auth Manually created authorization to use
-      # @option options [String] :google_client_email A @developer.gserviceaccount.com email address to use
       # @option options [String] :google_key_location The location of a pkcs12 key file
       # @option options [String] :google_key_string The content of the pkcs12 key file
       # @option options [String] :google_json_key_location The location of a JSON key file
@@ -65,6 +64,11 @@ module Fog
           raise ArgumentError.new("Deprecated argument no longer works: google_key_string")
         end
 
+
+        if options[:google_client_email]
+          Fog::Logger.warning("Deprecated argument no longer required: google_client_email")
+        end
+
         # Validate required arguments
         unless options[:google_api_scope_url]
           raise ArgumentError.new("Missing required arguments: google_api_scope_url")
@@ -95,11 +99,6 @@ module Fog
           json_key_hash = Fog::JSON.decode(json_key)
           unless json_key_hash.key?("client_email") || json_key_hash.key?("private_key")
             raise ArgumentError.new("Invalid Google JSON key")
-          end
-
-          options[:google_client_email] = json_key_hash["client_email"]
-          unless options[:google_client_email]
-            raise ArgumentError.new("Missing required arguments: google_client_email")
           end
 
           auth = ::Google::Auth::ServiceAccountCredentials.make_creds(

--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -20,6 +20,7 @@ module Fog
       # Initializes the Google API Client
       #
       # @param [Hash] options Google API options
+      # @option options [Bool]   :google_application_default Explicitly use application default credentials
       # @option options [Google::Auth|Signet] :google_auth Manually created authorization to use
       # @option options [String] :google_key_location The location of a pkcs12 key file
       # @option options [String] :google_key_string The content of the pkcs12 key file
@@ -70,7 +71,7 @@ module Fog
           auth = process_key_auth(options)
         elsif options[:google_auth]
           auth = options[:google_auth]
-        elsif options[:application_default]
+        elsif options[:google_application_default]
           auth = process_application_default_auth(options)
         else
           auth = process_fallback_auth(options)
@@ -179,7 +180,7 @@ module Fog
                 "- :google_json_key_location,\n" \
                 "- :google_json_key_string,\n" \
                 "- :google_auth,\n" \
-                "- :application_default,\n" \
+                "- :google_application_default,\n" \
                 "If credentials are valid - please, file a bug to fog-google." \
           )
         end

--- a/lib/fog/google/sql.rb
+++ b/lib/fog/google/sql.rb
@@ -10,7 +10,6 @@ module Fog
         :app_version,
         :google_auth,
         :google_client,
-        :google_client_email,
         :google_client_options,
         :google_key_location,
         :google_key_string,

--- a/lib/fog/storage/google_json.rb
+++ b/lib/fog/storage/google_json.rb
@@ -11,7 +11,6 @@ module Fog
         :app_version,
         :google_auth,
         :google_client,
-        :google_client_email,
         :google_client_options,
         :google_key_location,
         :google_key_string,

--- a/test/integration/test_authentication.rb
+++ b/test/integration/test_authentication.rb
@@ -27,13 +27,6 @@ class TestAuthentication < FogIntegrationTest
     assert_raises(ArgumentError) { Fog::Compute::Google.new(:google_project => nil) }
   end
 
-  def test_raises_argument_error_when_google_client_email_is_missing
-    assert_raises(ArgumentError) do
-      Fog::Compute::Google.new(:google_client_email => nil,
-                               :google_json_key_location => nil)
-    end # JSON key overrides google_client_email
-  end
-
   def test_raises_argument_error_when_google_keys_are_given
     assert_raises(ArgumentError) do
       Fog::Compute::Google.new(:google_key_location => nil,

--- a/test/unit/storage/test_json_requests.rb
+++ b/test/unit/storage/test_json_requests.rb
@@ -4,7 +4,6 @@ class UnitTestJsonRequests < MiniTest::Test
   def setup
     Fog.mock!
     @client = Fog::Storage.new(provider: "google",
-                               google_client_email: "",
                                google_project: "",
                                google_json_key_location: "")
   end


### PR DESCRIPTION
This PR centers around:
- Reworking credentials workflow to be easier to read and fall back to google application default credentials
- Removing deprecated `google_client_email` parameter everywhere