### PR TITLE
Update service options with new client option

### DIFF
--- a/lib/fog/dns/google.rb
+++ b/lib/fog/dns/google.rb
@@ -8,6 +8,7 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_application_default,
         :google_auth,
         :google_client,
         :google_client_options,

--- a/lib/fog/google/monitoring.rb
+++ b/lib/fog/google/monitoring.rb
@@ -8,6 +8,8 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_application_default,
+        :google_auth,
         :google_client,
         :google_client_options,
         :google_key_location,

--- a/lib/fog/google/pubsub.rb
+++ b/lib/fog/google/pubsub.rb
@@ -8,6 +8,7 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_application_default,
         :google_auth,
         :google_client,
         :google_client_options,

--- a/lib/fog/google/sql.rb
+++ b/lib/fog/google/sql.rb
@@ -8,6 +8,7 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_application_default,
         :google_auth,
         :google_client,
         :google_client_options,

--- a/lib/fog/storage/google_json.rb
+++ b/lib/fog/storage/google_json.rb
@@ -9,6 +9,7 @@ module Fog
       recognizes(
         :app_name,
         :app_version,
+        :google_application_default,
         :google_auth,
         :google_client,
         :google_client_options,


### PR DESCRIPTION
Add :google_application_default to avoid “unrecognised parameter” warnings