### PR TITLE
Cache bundling artefacts

### DIFF
--- a/ci/pipeline-dev.yml
+++ b/ci/pipeline-dev.yml
@@ -1,0 +1,58 @@
+jobs:
+  - name: integration-tests-monitoring
+    serial: true
+    plan:
+      - get: fog-google-src
+        resource: pull-request
+        version: every
+        trigger: true
+      - put: pull-request
+        params: {path: fog-google-src, status: pending}
+
+      - task: run-integration-tests
+        file: fog-google-src/ci/tasks/run-int.yml
+        params:
+          rake_task: test:monitoring
+          codecov_token: {{codecov_token}}
+          google_project: {{google_project}}
+          google_json_key_data: {{google_json_key_data}}
+        on_failure:
+          put: pull-request
+          params:
+            path: fog-google-src
+            status: failure
+
+  - name: github-pr-aggregator
+    plan:
+      - get: fog-google-src
+        resource: pull-request
+        passed: [integration-tests-monitoring]
+        trigger: true
+        on_success:
+          put: pull-request
+          params:
+            path: fog-google-src
+            status: success
+        on_failure:
+          put: pull-request
+          params:
+            path: fog-google-src
+            status: failure
+
+resources:
+  - name: pull-request
+    type: pull-request
+    source:
+      access_token: {{github_access_token}}
+      private_key: {{github_private_key}}
+      label: integrate-dev
+      repo: fog/fog-google
+
+resource_types:
+  # This is a third party resource.
+  # The referenced docker-image is maintained externally
+  # https://github.com/jtarchie/pullrequest-resource
+  - name: pull-request
+    type: docker-image
+    source:
+      repository: jtarchie/pr

--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -27,8 +27,18 @@ EOL
 
 pushd ${release_dir} > /dev/null
 
-bundle install --jobs=3 --retry=3
+echo "Exporting bundler options..."
 
+# Setting via local config options as BUNDLE_PATH appears to not work
+# see https://github.com/rails/spring/issues/339
+bundle config --local path ../../bundle
+bundle config --local bin ../../bundle/bin
+
+echo "Checking dependencies..."
+# Check if dependencies are satisfied, otherwise kick off bundle install
+bundle check || bundle install --jobs=3 --retry=3
+
+echo "Starting test run..."
 FOG_MOCK=false COVERAGE=true CODECOV_TOKEN=${codecov_token} rake ${rake_task}
 
 popd > /dev/null

--- a/ci/tasks/run-int.yml
+++ b/ci/tasks/run-int.yml
@@ -8,6 +8,8 @@ inputs:
   path: src/fog-google
 run:
   path: src/fog-google/ci/tasks/run-int.sh
+caches:
+- path: bundle
 params:
   rake_task: replace-me
   codecov_token: replace-me


### PR DESCRIPTION
Implementing worker-side caching of dependencies between jobs. This should shave off 1-2 minutes for each build task and lower the amount of ingress traffic to workers.