### PR TITLE
Don’t count non-implemented mocks in code coverage

### DIFF
--- a/lib/fog/compute/google/requests/abandon_instances.rb
+++ b/lib/fog/compute/google/requests/abandon_instances.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def abandon_instances(_instance_group_manager, _instances)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/add_backend_service_backends.rb
+++ b/lib/fog/compute/google/requests/add_backend_service_backends.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def add_backend_service_backends(_backend_service, _new_backends)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/add_instance_group_instances.rb
+++ b/lib/fog/compute/google/requests/add_instance_group_instances.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def add_instance_group_instances(_group_name, _zone, _instances)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/add_server_access_config.rb
+++ b/lib/fog/compute/google/requests/add_server_access_config.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def add_server_access_config(_identity, _zone, _nic, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/add_target_pool_health_checks.rb
+++ b/lib/fog/compute/google/requests/add_target_pool_health_checks.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def add_target_pool_health_checks(_target_pool, _region, _health_checks)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/add_target_pool_instances.rb
+++ b/lib/fog/compute/google/requests/add_target_pool_instances.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def add_target_pool_instances(_target_pool, _region, _instances)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/attach_disk.rb
+++ b/lib/fog/compute/google/requests/attach_disk.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def attach_disk(_instance, _zone, _disk = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/create_disk_snapshot.rb
+++ b/lib/fog/compute/google/requests/create_disk_snapshot.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def create_disk_snapshot(_snapshot_name, _disk, _zone, _snapshot = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_address.rb
+++ b/lib/fog/compute/google/requests/delete_address.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_address(_address_name, _region_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_backend_service.rb
+++ b/lib/fog/compute/google/requests/delete_backend_service.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_backend_service(_backend_service_name, _zone_name = nil)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_disk.rb
+++ b/lib/fog/compute/google/requests/delete_disk.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_disk(_disk_name, _zone_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_firewall.rb
+++ b/lib/fog/compute/google/requests/delete_firewall.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_firewall(_firewall_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_forwarding_rule.rb
+++ b/lib/fog/compute/google/requests/delete_forwarding_rule.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_forwarding_rule(_rule, _region)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_global_address.rb
+++ b/lib/fog/compute/google/requests/delete_global_address.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_global_address(_address_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_global_forwarding_rule.rb
+++ b/lib/fog/compute/google/requests/delete_global_forwarding_rule.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_global_forwarding_rule(_rule)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_global_operation.rb
+++ b/lib/fog/compute/google/requests/delete_global_operation.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_global_operation(_operation)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_http_health_check.rb
+++ b/lib/fog/compute/google/requests/delete_http_health_check.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_http_health_check(_check_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_image.rb
+++ b/lib/fog/compute/google/requests/delete_image.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_image(_image_name, _project = @project)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_instance_group.rb
+++ b/lib/fog/compute/google/requests/delete_instance_group.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_instance_group(_group_name, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_instance_group_manager.rb
+++ b/lib/fog/compute/google/requests/delete_instance_group_manager.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_instance_group_manager(_name, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_instance_template.rb
+++ b/lib/fog/compute/google/requests/delete_instance_template.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_instance_template(_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_network.rb
+++ b/lib/fog/compute/google/requests/delete_network.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_network(_network_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_region_operation.rb
+++ b/lib/fog/compute/google/requests/delete_region_operation.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_region_operation(_region, _operation)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_route.rb
+++ b/lib/fog/compute/google/requests/delete_route.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_route(_identity)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_server.rb
+++ b/lib/fog/compute/google/requests/delete_server.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_server(_server, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_server_access_config.rb
+++ b/lib/fog/compute/google/requests/delete_server_access_config.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_server_access_config(_identity, _zone, _nic, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_snapshot.rb
+++ b/lib/fog/compute/google/requests/delete_snapshot.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_snapshot(_snapshot_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/delete_ssl_certificate.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_ssl_certificate(_certificate_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_subnetwork.rb
+++ b/lib/fog/compute/google/requests/delete_subnetwork.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_subnetwork(_subnetwork_name, _region_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_target_http_proxy.rb
+++ b/lib/fog/compute/google/requests/delete_target_http_proxy.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_target_http_proxy(_proxy_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/delete_target_https_proxy.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_target_https_proxy(_proxy_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_target_instance.rb
+++ b/lib/fog/compute/google/requests/delete_target_instance.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_target_instance(_target_name, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_target_pool.rb
+++ b/lib/fog/compute/google/requests/delete_target_pool.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_target_pool(_target_pool, _region)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_url_map.rb
+++ b/lib/fog/compute/google/requests/delete_url_map.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_url_map(_url_map_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/delete_zone_operation.rb
+++ b/lib/fog/compute/google/requests/delete_zone_operation.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def delete_zone_operation(_zone, _operation)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/deprecate_image.rb
+++ b/lib/fog/compute/google/requests/deprecate_image.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def deprecate_image(_image_name, _deprecation_status = {}, _project = @project)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/detach_disk.rb
+++ b/lib/fog/compute/google/requests/detach_disk.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def detach_disk(_instance, _zone, _device_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/expand_subnetwork_ip_cidr_range.rb
+++ b/lib/fog/compute/google/requests/expand_subnetwork_ip_cidr_range.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def expand_subnetwork_ip_cidr_range(_subnetwork, _region, _ip_cidr_range)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_address.rb
+++ b/lib/fog/compute/google/requests/get_address.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_address(_address_name, _region_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_backend_service_health.rb
+++ b/lib/fog/compute/google/requests/get_backend_service_health.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_backend_service_health(_backend_service)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_disk.rb
+++ b/lib/fog/compute/google/requests/get_disk.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_disk(_disk_name, _zone_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_disk_type.rb
+++ b/lib/fog/compute/google/requests/get_disk_type.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_disk_type(_disk, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_firewall.rb
+++ b/lib/fog/compute/google/requests/get_firewall.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_firewall(_firewall_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_forwarding_rule.rb
+++ b/lib/fog/compute/google/requests/get_forwarding_rule.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_forwarding_rule(_rule, _region)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_global_address.rb
+++ b/lib/fog/compute/google/requests/get_global_address.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_global_address(_address_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_global_forwarding_rule.rb
+++ b/lib/fog/compute/google/requests/get_global_forwarding_rule.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_global_forwarding_rule(_rule)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_global_operation.rb
+++ b/lib/fog/compute/google/requests/get_global_operation.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_global_operation(_operation)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_http_health_check.rb
+++ b/lib/fog/compute/google/requests/get_http_health_check.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_http_health_check(_check_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_image.rb
+++ b/lib/fog/compute/google/requests/get_image.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_image(_image_name, _project = @project)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_image_from_family.rb
+++ b/lib/fog/compute/google/requests/get_image_from_family.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_image_from_family(_family, _project = @project)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_instance_group.rb
+++ b/lib/fog/compute/google/requests/get_instance_group.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_instance_group(_group_name, _zone, _project = @project)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_instance_group_manager.rb
+++ b/lib/fog/compute/google/requests/get_instance_group_manager.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_instance_group_manager(_name, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_instance_template.rb
+++ b/lib/fog/compute/google/requests/get_instance_template.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_instance_template(_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_machine_type.rb
+++ b/lib/fog/compute/google/requests/get_machine_type.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_machine_type(_machine_type, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_network.rb
+++ b/lib/fog/compute/google/requests/get_network.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_network(_network_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_project.rb
+++ b/lib/fog/compute/google/requests/get_project.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_project(_identity)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_region.rb
+++ b/lib/fog/compute/google/requests/get_region.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_region(_identity)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_route.rb
+++ b/lib/fog/compute/google/requests/get_route.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_route(_identity)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_server.rb
+++ b/lib/fog/compute/google/requests/get_server.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_server(_instance, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_server_serial_port_output.rb
+++ b/lib/fog/compute/google/requests/get_server_serial_port_output.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_server_serial_port_output(_identity, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_snapshot.rb
+++ b/lib/fog/compute/google/requests/get_snapshot.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_snapshot(_snap_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/get_ssl_certificate.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_ssl_certificate(_certificate_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_subnetwork.rb
+++ b/lib/fog/compute/google/requests/get_subnetwork.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_subnetwork(_subnetwork_name, _region_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_target_http_proxy.rb
+++ b/lib/fog/compute/google/requests/get_target_http_proxy.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_target_http_proxy(_proxy_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/get_target_https_proxy.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_target_https_proxy(_proxy_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_target_instance.rb
+++ b/lib/fog/compute/google/requests/get_target_instance.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_target_instance(_target_name, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_target_pool.rb
+++ b/lib/fog/compute/google/requests/get_target_pool.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_target_pool(_target_pool, _region)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_target_pool_health.rb
+++ b/lib/fog/compute/google/requests/get_target_pool_health.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_target_pool_health(_target_pool, _region, _instance)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_url_map.rb
+++ b/lib/fog/compute/google/requests/get_url_map.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_url_map(_url_map_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_zone.rb
+++ b/lib/fog/compute/google/requests/get_zone.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_zone(_zone_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/get_zone_operation.rb
+++ b/lib/fog/compute/google/requests/get_zone_operation.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def get_zone_operation(_zone_name, _operation)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_address.rb
+++ b/lib/fog/compute/google/requests/insert_address.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_address(_address_name, _region_name, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_backend_service.rb
+++ b/lib/fog/compute/google/requests/insert_backend_service.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_backend_service(_backend_service_name, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_disk.rb
+++ b/lib/fog/compute/google/requests/insert_disk.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_disk(_disk_name, _zone, _image_name = nil, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_firewall.rb
+++ b/lib/fog/compute/google/requests/insert_firewall.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_firewall(_firewall_name, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_forwarding_rule.rb
+++ b/lib/fog/compute/google/requests/insert_forwarding_rule.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_forwarding_rule(_rule_name, _region, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_global_address.rb
+++ b/lib/fog/compute/google/requests/insert_global_address.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_global_address(_address_name, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_global_forwarding_rule.rb
+++ b/lib/fog/compute/google/requests/insert_global_forwarding_rule.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_global_forwarding_rule(_rule_name, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_http_health_check.rb
+++ b/lib/fog/compute/google/requests/insert_http_health_check.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_http_health_check(_check_name, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_image.rb
+++ b/lib/fog/compute/google/requests/insert_image.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_image(_image_name, _image = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_instance_group.rb
+++ b/lib/fog/compute/google/requests/insert_instance_group.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_instance_group(_group_name, _zone, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_instance_group_manager.rb
+++ b/lib/fog/compute/google/requests/insert_instance_group_manager.rb
@@ -4,7 +4,9 @@ module Fog
       class Mock
         def insert_instance_group_manager(_name, _zone, _instance_template, _base_instance_name,
                                           _target_size, _target_pools, _named_ports, _description)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_instance_template.rb
+++ b/lib/fog/compute/google/requests/insert_instance_template.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_instance_template(_name, _properties, _description)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_network.rb
+++ b/lib/fog/compute/google/requests/insert_network.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_network(_network_name, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_route.rb
+++ b/lib/fog/compute/google/requests/insert_route.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_route(_route_name, _network, _dest_range, _priority, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_server.rb
+++ b/lib/fog/compute/google/requests/insert_server.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_server(_instance_name, _zone, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_ssl_certificate.rb
+++ b/lib/fog/compute/google/requests/insert_ssl_certificate.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_ssl_certificate(_certificate_name, _certificate, _private_key, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_subnetwork.rb
+++ b/lib/fog/compute/google/requests/insert_subnetwork.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_subnetwork(_subnetwork_name, _region_name, _network, _ip_range, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_target_http_proxy.rb
+++ b/lib/fog/compute/google/requests/insert_target_http_proxy.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_target_http_proxy(_proxy_name, _description: nil, _url_map: nil)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_target_https_proxy.rb
+++ b/lib/fog/compute/google/requests/insert_target_https_proxy.rb
@@ -4,7 +4,9 @@ module Fog
       class Mock
         def insert_target_https_proxy(_proxy_name, _description: nil,
                                       _url_map: nil, _ssl_certificates: nil)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_target_instance.rb
+++ b/lib/fog/compute/google/requests/insert_target_instance.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_target_instance(_target_name, _zone, _target_instance = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_target_pool.rb
+++ b/lib/fog/compute/google/requests/insert_target_pool.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_target_pool(_target_pool_name, _region, _target_pool = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/insert_url_map.rb
+++ b/lib/fog/compute/google/requests/insert_url_map.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def insert_url_map(_url_map_name, _url_map = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/invalidate_url_map_cache.rb
+++ b/lib/fog/compute/google/requests/invalidate_url_map_cache.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def invalidate_url_map_cache(_url_map_name, _path, _host = nil)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_addresses.rb
+++ b/lib/fog/compute/google/requests/list_addresses.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_addresses(_region_name, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_addresses.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_addresses.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_addresses(_options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_disk_types.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_disk_types.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_disk_types(_options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_disks.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_disks.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_disks(_options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_forwarding_rules.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_forwarding_rules.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_forwarding_rules(_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_instance_group_managers.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_instance_group_managers.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_instance_group_managers(_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_instance_groups.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_instance_groups.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_instance_groups(_options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_machine_types.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_machine_types.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_machine_types(_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_servers.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_servers.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_servers(_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_subnetworks.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_subnetworks.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_subnetworks(_options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_target_instances.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_target_instances.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_target_instances(_options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_aggregated_target_pools.rb
+++ b/lib/fog/compute/google/requests/list_aggregated_target_pools.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_aggregated_target_pools(_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_disk_types.rb
+++ b/lib/fog/compute/google/requests/list_disk_types.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_disk_types(_zone, _options: {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_disks.rb
+++ b/lib/fog/compute/google/requests/list_disks.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_disks(_zone_name, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_firewalls.rb
+++ b/lib/fog/compute/google/requests/list_firewalls.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_firewalls
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_forwarding_rules.rb
+++ b/lib/fog/compute/google/requests/list_forwarding_rules.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_forwarding_rules(_region, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_global_addresses.rb
+++ b/lib/fog/compute/google/requests/list_global_addresses.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_global_addresses(_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_global_forwarding_rules.rb
+++ b/lib/fog/compute/google/requests/list_global_forwarding_rules.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_global_forwarding_rules(_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_global_operations.rb
+++ b/lib/fog/compute/google/requests/list_global_operations.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_global_operations
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_http_health_checks.rb
+++ b/lib/fog/compute/google/requests/list_http_health_checks.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_http_health_checks
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_images.rb
+++ b/lib/fog/compute/google/requests/list_images.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_images(_project = @project, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_instance_group_instances.rb
+++ b/lib/fog/compute/google/requests/list_instance_group_instances.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_instance_group_instances(_group, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_instance_group_managers.rb
+++ b/lib/fog/compute/google/requests/list_instance_group_managers.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_instance_group_managers(_zone, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_instance_groups.rb
+++ b/lib/fog/compute/google/requests/list_instance_groups.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_instance_groups(_zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_instance_templates.rb
+++ b/lib/fog/compute/google/requests/list_instance_templates.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_instance_templates
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_machine_types.rb
+++ b/lib/fog/compute/google/requests/list_machine_types.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_machine_types(_zone, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_networks.rb
+++ b/lib/fog/compute/google/requests/list_networks.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_networks(_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_region_operations.rb
+++ b/lib/fog/compute/google/requests/list_region_operations.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_region_operations(_region)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_regions.rb
+++ b/lib/fog/compute/google/requests/list_regions.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_regions
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_routes.rb
+++ b/lib/fog/compute/google/requests/list_routes.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_routes(_options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_servers.rb
+++ b/lib/fog/compute/google/requests/list_servers.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_servers(_zone, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_snapshots.rb
+++ b/lib/fog/compute/google/requests/list_snapshots.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_snapshots
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_ssl_certificates.rb
+++ b/lib/fog/compute/google/requests/list_ssl_certificates.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_ssl_certificates
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_subnetworks.rb
+++ b/lib/fog/compute/google/requests/list_subnetworks.rb
@@ -4,7 +4,9 @@ module Fog
       class Mock
         def list_subnetworks(_region_name, _filter: nil, _max_results: nil,
                              _order_by: nil, _page_token: nil)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_target_http_proxies.rb
+++ b/lib/fog/compute/google/requests/list_target_http_proxies.rb
@@ -4,7 +4,9 @@ module Fog
       class Mock
         def list_target_http_proxies(_filter: nil, _max_results: nil,
                                      _order_by: nil, _page_token: nil)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_target_https_proxies.rb
+++ b/lib/fog/compute/google/requests/list_target_https_proxies.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_target_https_proxies
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_target_instances.rb
+++ b/lib/fog/compute/google/requests/list_target_instances.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_target_instances(_zone, _opts: {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_target_pools.rb
+++ b/lib/fog/compute/google/requests/list_target_pools.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_target_pools(_region, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_url_maps.rb
+++ b/lib/fog/compute/google/requests/list_url_maps.rb
@@ -4,7 +4,9 @@ module Fog
       class Mock
         def list_url_maps(_filter: nil, _max_results: nil,
                           _order_by: nil, _page_token: nil)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_zone_operations.rb
+++ b/lib/fog/compute/google/requests/list_zone_operations.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_zone_operations(_zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/list_zones.rb
+++ b/lib/fog/compute/google/requests/list_zones.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def list_zones
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/patch_firewall.rb
+++ b/lib/fog/compute/google/requests/patch_firewall.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def patch_firewall(_firewall_name, _firewall_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/patch_url_map.rb
+++ b/lib/fog/compute/google/requests/patch_url_map.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def patch_url_map(_url_map_name, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/recreate_instances.rb
+++ b/lib/fog/compute/google/requests/recreate_instances.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def recreate_instances(_instance_group_manager, _instances)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/remove_instance_group_instances.rb
+++ b/lib/fog/compute/google/requests/remove_instance_group_instances.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def add_instance_group_instances(_group, _zone, _instances)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/remove_target_pool_health_checks.rb
+++ b/lib/fog/compute/google/requests/remove_target_pool_health_checks.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def remove_target_pool_health_checks(_target_pool, _region, _health_checks)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/remove_target_pool_instance.rb
+++ b/lib/fog/compute/google/requests/remove_target_pool_instance.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def remove_target_pool_instances(_target_pool, _region, _instances)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/remove_target_pool_instances.rb
+++ b/lib/fog/compute/google/requests/remove_target_pool_instances.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def remove_target_pool_instances(_target_pool, _region, _instances)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/reset_server.rb
+++ b/lib/fog/compute/google/requests/reset_server.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def reset_server(_identity, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_common_instance_metadata.rb
+++ b/lib/fog/compute/google/requests/set_common_instance_metadata.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_common_instance_metadata(_project, _current_fingerprint, _metadata = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_forwarding_rule_target.rb
+++ b/lib/fog/compute/google/requests/set_forwarding_rule_target.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_forwarding_rule_target(_rule_name, _region, _target_opts)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_global_forwarding_rule_target.rb
+++ b/lib/fog/compute/google/requests/set_global_forwarding_rule_target.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_global_forwarding_rule_target(_rule_name, _target)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_instance_template.rb
+++ b/lib/fog/compute/google/requests/set_instance_template.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_instance_template(_instance_group_manager, _instance_template)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_server_disk_auto_delete.rb
+++ b/lib/fog/compute/google/requests/set_server_disk_auto_delete.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_server_disk_auto_delete(_identity, _zone, _auto_delete, _device_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_server_metadata.rb
+++ b/lib/fog/compute/google/requests/set_server_metadata.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_server_metadata(_instance, _zone, _fingerprint, _metadata_items = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_server_scheduling.rb
+++ b/lib/fog/compute/google/requests/set_server_scheduling.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_server_scheduling(_identity, _zone, _on_host_maintenance, _automatic_restart, _preemptible)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_server_tags.rb
+++ b/lib/fog/compute/google/requests/set_server_tags.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_server_tags(_instance, _zone, _tags = [])
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_snapshot_labels.rb
+++ b/lib/fog/compute/google/requests/set_snapshot_labels.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_snapshot_labels(_snap_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_subnetwork_private_ip_google_access.rb
+++ b/lib/fog/compute/google/requests/set_subnetwork_private_ip_google_access.rb
@@ -5,7 +5,9 @@ module Fog
         def set_subnetwork_private_ip_google_access(_subnetwork_name,
                                                     _region_name,
                                                     _private_ip_google_access)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_target_http_proxy_url_map.rb
+++ b/lib/fog/compute/google/requests/set_target_http_proxy_url_map.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_target_http_proxy_url_map(_proxy_name, _url_map)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_target_https_proxy_ssl_certificates.rb
+++ b/lib/fog/compute/google/requests/set_target_https_proxy_ssl_certificates.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_target_https_proxy_ssl_certificates(_proxy_name, _certs)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_target_https_proxy_url_map.rb
+++ b/lib/fog/compute/google/requests/set_target_https_proxy_url_map.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def set_target_https_proxy_url_map(_proxy_name, _url_map)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/set_target_pool_backup.rb
+++ b/lib/fog/compute/google/requests/set_target_pool_backup.rb
@@ -4,7 +4,9 @@ module Fog
       class Mock
         def set_target_pool_backup(_target_pool, _region, _backup_target,
                                    _failover_ratio: nil)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/start_server.rb
+++ b/lib/fog/compute/google/requests/start_server.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def start_server(_identity, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/stop_server.rb
+++ b/lib/fog/compute/google/requests/stop_server.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def stop_server(_identity, _zone)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/update_firewall.rb
+++ b/lib/fog/compute/google/requests/update_firewall.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def update_firewall(_firewall_name, _firewall_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/update_http_health_check.rb
+++ b/lib/fog/compute/google/requests/update_http_health_check.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def update_http_health_check(_check_name, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/update_url_map.rb
+++ b/lib/fog/compute/google/requests/update_url_map.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def update_url_map(_url_map_name, _url_map = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/compute/google/requests/validate_url_map.rb
+++ b/lib/fog/compute/google/requests/validate_url_map.rb
@@ -3,7 +3,9 @@ module Fog
     class Google
       class Mock
         def validate_url_map(_url_map_name, _url_map: {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/lib/fog/dns/google/requests/create_change.rb
+++ b/lib/fog/dns/google/requests/create_change.rb
@@ -19,7 +19,9 @@ module Fog
 
       class Mock
         def create_change(_zone_name_or_id, _additions = [], _deletions = [])
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/dns/google/requests/create_managed_zone.rb
+++ b/lib/fog/dns/google/requests/create_managed_zone.rb
@@ -19,7 +19,9 @@ module Fog
 
       class Mock
         def create_managed_zone(_name, _dns_name, _description)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/dns/google/requests/delete_managed_zone.rb
+++ b/lib/fog/dns/google/requests/delete_managed_zone.rb
@@ -13,7 +13,9 @@ module Fog
 
       class Mock
         def delete_managed_zone(_name_or_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/dns/google/requests/get_change.rb
+++ b/lib/fog/dns/google/requests/get_change.rb
@@ -13,7 +13,9 @@ module Fog
 
       class Mock
         def get_change(_zone_name_or_id, _identity)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/dns/google/requests/get_managed_zone.rb
+++ b/lib/fog/dns/google/requests/get_managed_zone.rb
@@ -13,7 +13,9 @@ module Fog
 
       class Mock
         def get_managed_zone(_name_or_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/dns/google/requests/get_project.rb
+++ b/lib/fog/dns/google/requests/get_project.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def get_project(_identity)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/dns/google/requests/list_changes.rb
+++ b/lib/fog/dns/google/requests/list_changes.rb
@@ -20,7 +20,9 @@ module Fog
 
       class Mock
         def list_changes(_zone_name_or_id, _opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/dns/google/requests/list_managed_zones.rb
+++ b/lib/fog/dns/google/requests/list_managed_zones.rb
@@ -16,7 +16,9 @@ module Fog
 
       class Mock
         def list_managed_zones(_opts = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/dns/google/requests/list_resource_record_sets.rb
+++ b/lib/fog/dns/google/requests/list_resource_record_sets.rb
@@ -20,7 +20,9 @@ module Fog
 
       class Mock
         def list_resource_record_sets(_zone_name_or_id, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/monitoring/create_metric_descriptor.rb
+++ b/lib/fog/google/requests/monitoring/create_metric_descriptor.rb
@@ -41,7 +41,9 @@ module Fog
 
       class Mock
         def create_metric_descriptor(**_args)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/monitoring/create_timeseries.rb
+++ b/lib/fog/google/requests/monitoring/create_timeseries.rb
@@ -19,7 +19,9 @@ module Fog
 
       class Mock
         def create_timeseries(_timeseries: [])
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/monitoring/delete_metric_descriptor.rb
+++ b/lib/fog/google/requests/monitoring/delete_metric_descriptor.rb
@@ -9,7 +9,9 @@ module Fog
 
       class Mock
         def delete_metric_descriptor(_metric_type)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/monitoring/get_metric_descriptor.rb
+++ b/lib/fog/google/requests/monitoring/get_metric_descriptor.rb
@@ -9,7 +9,9 @@ module Fog
 
       class Mock
         def get_metric_descriptor(_metric_type)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/monitoring/list_monitored_resource_descriptors.rb
+++ b/lib/fog/google/requests/monitoring/list_monitored_resource_descriptors.rb
@@ -19,7 +19,9 @@ module Fog
 
       class Mock
         def list_monitored_resource_descriptors(_filter, _page_size, _page_token)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/monitoring/list_timeseries.rb
+++ b/lib/fog/google/requests/monitoring/list_timeseries.rb
@@ -45,7 +45,9 @@ module Fog
 
       class Mock
         def list_timeseries(_options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/clone_instance.rb
+++ b/lib/fog/google/requests/sql/clone_instance.rb
@@ -32,7 +32,9 @@ module Fog
       class Mock
         def clone_instance(_instance_id, _destination_name,
                            _log_filename: nil, _log_position: nil)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/delete_backup_run.rb
+++ b/lib/fog/google/requests/sql/delete_backup_run.rb
@@ -13,7 +13,9 @@ module Fog
 
       class Mock
         def delete_backup_run(_instance_id, _run)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/delete_instance.rb
+++ b/lib/fog/google/requests/sql/delete_instance.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def delete_instance(_instance_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/delete_ssl_cert.rb
+++ b/lib/fog/google/requests/sql/delete_ssl_cert.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def delete_ssl_cert(_instance_id, _sha1_fingerprint)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/delete_user.rb
+++ b/lib/fog/google/requests/sql/delete_user.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def delete_user(_instance_id, _host, _name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/export_instance.rb
+++ b/lib/fog/google/requests/sql/export_instance.rb
@@ -45,7 +45,9 @@ module Fog
 
       class Mock
         def export_instance(_instance_id, _uri, _options: {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/get_backup_run.rb
+++ b/lib/fog/google/requests/sql/get_backup_run.rb
@@ -13,7 +13,9 @@ module Fog
 
       class Mock
         def get_backup_run(_instance_id, _backup_run_id, _due_time)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/get_instance.rb
+++ b/lib/fog/google/requests/sql/get_instance.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def get_instance(_instance_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/get_operation.rb
+++ b/lib/fog/google/requests/sql/get_operation.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def get_operation(_operation_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/get_ssl_cert.rb
+++ b/lib/fog/google/requests/sql/get_ssl_cert.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def get_ssl_cert(_instance_id, _sha1_fingerprint)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/import_instance.rb
+++ b/lib/fog/google/requests/sql/import_instance.rb
@@ -34,7 +34,9 @@ module Fog
 
       class Mock
         def import_instance(_instance_id, _uri, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/insert_backup_run.rb
+++ b/lib/fog/google/requests/sql/insert_backup_run.rb
@@ -18,7 +18,9 @@ module Fog
 
       class Mock
         def insert_backup_run(_instance_id, _run)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/insert_instance.rb
+++ b/lib/fog/google/requests/sql/insert_instance.rb
@@ -18,7 +18,9 @@ module Fog
 
       class Mock
         def insert_instance(_name, _tier, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/insert_ssl_cert.rb
+++ b/lib/fog/google/requests/sql/insert_ssl_cert.rb
@@ -20,7 +20,9 @@ module Fog
 
       class Mock
         def insert_ssl_cert(_instance_id, _common_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/insert_user.rb
+++ b/lib/fog/google/requests/sql/insert_user.rb
@@ -15,7 +15,9 @@ module Fog
 
       class Mock
         def insert_user(_instance_id, _user)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/list_backup_runs.rb
+++ b/lib/fog/google/requests/sql/list_backup_runs.rb
@@ -17,7 +17,9 @@ module Fog
 
       class Mock
         def list_backup_runs(_instance_id, _backup_configuration_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/list_flags.rb
+++ b/lib/fog/google/requests/sql/list_flags.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def list_flags
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/list_instances.rb
+++ b/lib/fog/google/requests/sql/list_instances.rb
@@ -17,7 +17,9 @@ module Fog
 
       class Mock
         def list_instances(_options: {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/list_operations.rb
+++ b/lib/fog/google/requests/sql/list_operations.rb
@@ -18,7 +18,9 @@ module Fog
 
       class Mock
         def list_operations(_instance_id, _options: {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/list_ssl_certs.rb
+++ b/lib/fog/google/requests/sql/list_ssl_certs.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def list_ssl_certs(_instance_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/list_tiers.rb
+++ b/lib/fog/google/requests/sql/list_tiers.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def list_tiers
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/list_users.rb
+++ b/lib/fog/google/requests/sql/list_users.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def list_operations(_instance_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/reset_instance_ssl_config.rb
+++ b/lib/fog/google/requests/sql/reset_instance_ssl_config.rb
@@ -16,7 +16,9 @@ module Fog
 
       class Mock
         def reset_instance_ssl_config(_instance_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/restart_instance.rb
+++ b/lib/fog/google/requests/sql/restart_instance.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def restart_instance(_instance_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/restore_instance_backup.rb
+++ b/lib/fog/google/requests/sql/restore_instance_backup.rb
@@ -21,7 +21,9 @@ module Fog
 
       class Mock
         def restore_instance_backup(_instance_id, _backup_run_id)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/update_instance.rb
+++ b/lib/fog/google/requests/sql/update_instance.rb
@@ -21,7 +21,9 @@ module Fog
 
       class Mock
         def update_instance(_instance_id, _settings_version, _tier, _settings = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/google/requests/sql/update_user.rb
+++ b/lib/fog/google/requests/sql/update_user.rb
@@ -17,7 +17,9 @@ module Fog
 
       class Mock
         def update_user(_instance_id, _host, _name, _user)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/copy_object.rb
+++ b/lib/fog/storage/google_json/requests/copy_object.rb
@@ -23,7 +23,9 @@ module Fog
       class Mock
         def copy_object(_source_bucket, _source_object,
                         _target_bucket, _target_object, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/delete_bucket.rb
+++ b/lib/fog/storage/google_json/requests/delete_bucket.rb
@@ -13,7 +13,9 @@ module Fog
 
       class Mock
         def delete_bucket(_bucket_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/delete_object.rb
+++ b/lib/fog/storage/google_json/requests/delete_object.rb
@@ -14,7 +14,9 @@ module Fog
 
       class Mock
         def delete_object(_bucket_name, _object_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/get_bucket.rb
+++ b/lib/fog/storage/google_json/requests/get_bucket.rb
@@ -33,7 +33,9 @@ module Fog
 
       class Mock
         def get_bucket(_bucket_name, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/get_bucket_acl.rb
+++ b/lib/fog/storage/google_json/requests/get_bucket_acl.rb
@@ -22,7 +22,9 @@ module Fog
 
       class Mock
         def get_bucket_acl(_bucket_name, _entity)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/get_object.rb
+++ b/lib/fog/storage/google_json/requests/get_object.rb
@@ -75,7 +75,9 @@ module Fog
 
       class Mock
         def get_object(_bucket_name, _object_name, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/get_object_acl.rb
+++ b/lib/fog/storage/google_json/requests/get_object_acl.rb
@@ -25,7 +25,9 @@ module Fog
 
       class Mock
         def get_object_acl(_bucket_name, _object_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/get_object_metadata.rb
+++ b/lib/fog/storage/google_json/requests/get_object_metadata.rb
@@ -22,7 +22,9 @@ module Fog
 
       class Mock
         def get_object_metadata(_bucket_name, _object_name, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/list_bucket_acl.rb
+++ b/lib/fog/storage/google_json/requests/list_bucket_acl.rb
@@ -16,7 +16,9 @@ module Fog
 
       class Mock
         def list_bucket_acl(_bucket_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/list_buckets.rb
+++ b/lib/fog/storage/google_json/requests/list_buckets.rb
@@ -20,7 +20,9 @@ module Fog
       end
       class Mock
         def list_buckets
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/list_object_acl.rb
+++ b/lib/fog/storage/google_json/requests/list_object_acl.rb
@@ -19,7 +19,9 @@ module Fog
 
       class Mock
         def list_object_acl(_bucket_name, _object_name)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/list_objects.rb
+++ b/lib/fog/storage/google_json/requests/list_objects.rb
@@ -38,7 +38,9 @@ module Fog
 
       class Mock
         def list_objects(_bucket, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/put_bucket.rb
+++ b/lib/fog/storage/google_json/requests/put_bucket.rb
@@ -32,7 +32,9 @@ module Fog
 
       class Mock
         def put_bucket(_bucket_name, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/put_bucket_acl.rb
+++ b/lib/fog/storage/google_json/requests/put_bucket_acl.rb
@@ -19,7 +19,9 @@ module Fog
 
       class Mock
         def put_bucket_acl(_bucket_name, _acl)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/put_object.rb
+++ b/lib/fog/storage/google_json/requests/put_object.rb
@@ -92,7 +92,9 @@ module Fog
 
       class Mock
         def put_object(_bucket_name, _object_name, _data, _options = {})
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/put_object_acl.rb
+++ b/lib/fog/storage/google_json/requests/put_object_acl.rb
@@ -25,7 +25,9 @@ module Fog
 
       class Mock
         def put_object_acl(_bucket_name, _object_name, _acl)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
     end

--- a/lib/fog/storage/google_xml/requests/put_bucket_acl.rb
+++ b/lib/fog/storage/google_xml/requests/put_bucket_acl.rb
@@ -3,7 +3,9 @@ module Fog
     class GoogleXML
       class Mock
         def put_bucket_acl(_bucket_name, _acl)
+          # :no-coverage:
           Fog::Mock.not_implemented
+          # :no-coverage:
         end
       end
 

--- a/test/helpers/test_helper.rb
+++ b/test/helpers/test_helper.rb
@@ -5,6 +5,7 @@ if ENV["COVERAGE"]
 
   require 'codecov'
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  SimpleCov.skip_token('no-coverage')
 
   SimpleCov.start do
     add_filter "/test/"


### PR DESCRIPTION
Looking at our coverage graphs we're counting in non-implemented mocks in code coverage which doesn't make much sense.

This PR is an attempt to fix that so finding models that need better coverage is easier.