### PR TITLE
Removing SD test skip

### DIFF
--- a/test/integration/monitoring/test_metric_descriptors.rb
+++ b/test/integration/monitoring/test_metric_descriptors.rb
@@ -107,8 +107,6 @@ class TestMetricDescriptors < FogIntegrationTest
   end
 
   def test_metric_descriptors_all_page_size
-    skip("Skipping until API-side issue is resolved, see #451")
-
     descriptors = @client.metric_descriptors.all(
       :filter => 'metric.type = starts_with("compute.googleapis.com")',
       :page_size => 5


### PR DESCRIPTION
Fixes #451 

```
λ bundle exec rake test TESTOPTS=" --name=/test_metric_descriptors_all_page_size/"                                                                            (130)
Started with run options --name=/test_metric_descriptors_all_page_size/ --seed 6843

TestMetricDescriptors
  test_metric_descriptors_all_page_size                           PASS (2.19s)

Finished in 2.20231s
1 tests, 2 assertions, 0 failures, 0 errors, 0 skips
```