### PR TITLE
handle bucket name that contains dot

### DIFF
--- a/lib/fog/storage/google_xml/requests/copy_object.rb
+++ b/lib/fog/storage/google_xml/requests/copy_object.rb
@@ -26,10 +26,10 @@ module Fog
           headers = { "x-goog-copy-source" => "/#{source_bucket_name}/#{source_object_name}" }.merge(options)
           request(:expects  => 200,
                   :headers  => headers,
-                  :host     => "#{target_bucket_name}.#{@host}",
+                  :host     => @host,
                   :method   => "PUT",
                   :parser   => Fog::Parsers::Storage::Google::CopyObject.new,
-                  :path     => Fog::Google.escape(target_object_name))
+                  :path     => "#{target_bucket_name}/#{Fog::Google.escape(target_object_name)}")
         end
       end
 

--- a/lib/fog/storage/google_xml/requests/delete_object.rb
+++ b/lib/fog/storage/google_xml/requests/delete_object.rb
@@ -14,10 +14,10 @@ module Fog
         def delete_object(bucket_name, object_name)
           request(:expects    => 204,
                   :headers    => {},
-                  :host       => "#{bucket_name}.#{@host}",
+                  :host       => @host,
                   :idempotent => true,
                   :method     => "DELETE",
-                  :path       => Fog::Google.escape(object_name))
+                  :path       => "#{bucket_name}/#{Fog::Google.escape(object_name)}")
         end
       end
 

--- a/lib/fog/storage/google_xml/requests/put_object.rb
+++ b/lib/fog/storage/google_xml/requests/put_object.rb
@@ -28,10 +28,10 @@ module Fog
           request(:body       => data[:body],
                   :expects    => 200,
                   :headers    => headers,
-                  :host       => "#{bucket_name}.#{@host}",
+                  :host       => @host,
                   :idempotent => true,
                   :method     => "PUT",
-                  :path       => Fog::Google.escape(object_name))
+                  :path       => "#{bucket_name}/#{Fog::Google.escape(object_name)}")
         end
       end
 


### PR DESCRIPTION
handle bucket name that contains dot, because with current code, if bucket name contains dot, it will return an ssl error, so it better to using another method than make bucket name as a subdomain.