### PR TITLE
Created set machine type request

### DIFF
--- a/lib/fog/compute/google.rb
+++ b/lib/fog/compute/google.rb
@@ -170,6 +170,7 @@ module Fog
       request :set_forwarding_rule_target
       request :set_global_forwarding_rule_target
       request :set_server_disk_auto_delete
+      request :set_server_machine_type
       request :set_server_metadata
       request :set_server_scheduling
       request :set_server_tags

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -414,6 +414,21 @@ module Fog
           reload
         end
 
+        def set_machine_type(new_machine_type, async = true)
+          requires :identity, :zone
+
+          raise Fog::Errors::Error.new("Instance must be stopped to change machine type") unless stopped?
+
+          data = service.set_server_machine_type(
+            identity, zone_name, new_machine_type
+          )
+          operation = Fog::Compute::Google::Operations
+                      .new(:service => service)
+                      .get(data.name, data.zone)
+          operation.wait_for { ready? } unless async
+          reload
+        end
+
         def set_tags(new_tags = [], async = true)
           requires :identity, :zone
 

--- a/lib/fog/compute/google/requests/set_server_machine_type.rb
+++ b/lib/fog/compute/google/requests/set_server_machine_type.rb
@@ -1,0 +1,23 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def set_server_machine_type(_instance, _zone, _machine_type)
+          # :no-coverage:
+          Fog::Mock.not_implemented
+          # :no-coverage:
+        end
+      end
+
+      class Real
+        def set_server_machine_type(instance, zone, machine_type)
+          request = ::Google::Apis::ComputeV1::InstancesSetMachineTypeRequest.new
+          zone = zone.split("/")[-1]
+          machine_type = machine_type.split("/")[-1]
+          request.machine_type = "zones/#{zone}/machineTypes/#{machine_type}"
+          @compute.set_instance_machine_type(@project, zone, instance, request)
+        end
+      end
+    end
+  end
+end

--- a/test/integration/compute/core_compute/test_servers.rb
+++ b/test/integration/compute/core_compute/test_servers.rb
@@ -20,6 +20,14 @@ class TestServers < FogIntegrationTest
     super
   end
 
+  def test_set_machine_type
+    server = @factory.create
+    server.stop
+    server.wait_for { stopped? }
+    server.set_machine_type('n1-standard-2', false)
+    assert_equal 'n1-standard-2', server.machine_type
+  end
+
   def test_set_metadata
     server = @factory.create
     server.wait_for { ready? }

--- a/test/integration/compute/core_compute/test_servers.rb
+++ b/test/integration/compute/core_compute/test_servers.rb
@@ -24,8 +24,16 @@ class TestServers < FogIntegrationTest
     server = @factory.create
     server.stop
     server.wait_for { stopped? }
-    server.set_machine_type('n1-standard-2', false)
-    assert_equal 'n1-standard-2', server.machine_type
+    server.set_machine_type("n1-standard-2", false)
+    assert_equal "n1-standard-2", server.machine_type
+  end
+
+  def test_set_machine_type_fail
+    server = @factory.create
+    server.wait_for { ready? }
+    assert_raises Fog::Errors::Error do
+      server.set_machine_type("n1-standard-2", false)
+    end
   end
 
   def test_set_metadata

--- a/test/integration/compute/core_compute/test_servers.rb
+++ b/test/integration/compute/core_compute/test_servers.rb
@@ -25,7 +25,7 @@ class TestServers < FogIntegrationTest
     server.stop
     server.wait_for { stopped? }
     server.set_machine_type("n1-standard-2", false)
-    assert_equal "n1-standard-2", server.machine_type
+    assert_equal "n1-standard-2", server.machine_type.split("/")[-1]
   end
 
   def test_set_machine_type_fail


### PR DESCRIPTION
Adds a set_server_machine_type request. This is useful for changing a server's machine type although the instance must be stopped to do so.

Signed-off-by: gscho <greg.c.schofield@gmail.com>