### PR TITLE
Fix Monitoring#create_time_series

### DIFF
--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -27,6 +27,12 @@ EOL
 
 pushd ${release_dir} > /dev/null
 
+echo "Ruby version:"
+ruby --version
+
+echo "Bundler version:"
+bundler --version
+
 echo "Exporting bundler options..."
 
 # Setting via local config options as BUNDLE_PATH appears to not work
@@ -37,6 +43,9 @@ bundle config --local bin ../../bundle/bin
 echo "Checking dependencies..."
 # Check if dependencies are satisfied, otherwise kick off bundle install
 bundle check || bundle install --jobs=3 --retry=3
+
+echo "Dependencies resolved to:"
+bundle list
 
 echo "Starting test run..."
 FOG_MOCK=false COVERAGE=true CODECOV_TOKEN=${codecov_token} rake ${rake_task}

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fog-xml", "~> 0.1.0"
 
   # Hard Requirement as of 1.0
-  spec.add_dependency "google-api-client", ">= 0.23", "< 0.34"
+  spec.add_dependency "google-api-client", ">= 0.32", "< 0.34"
   
   # Debugger
   spec.add_development_dependency "pry"

--- a/lib/fog/google/requests/monitoring/create_timeseries.rb
+++ b/lib/fog/google/requests/monitoring/create_timeseries.rb
@@ -13,7 +13,7 @@ module Fog
           request = ::Google::Apis::MonitoringV3::CreateTimeSeriesRequest.new(
             :time_series => timeseries
           )
-          @monitoring.create_time_series("projects/#{@project}", request)
+          @monitoring.create_project_time_series("projects/#{@project}", request)
         end
       end
 


### PR DESCRIPTION
It seems that the GoogleAPI client has made a breaking change again.

The method `create_time_series` no longer exists in the library and looks to have been replaced with `create_project_timeseries`.

We also need to bump the minimum gem version as this was introduced somewhere around `0.31`