### PR TITLE
Revert "Update fog-core requirement from <= 2.1.0 to <= 2.3.0"

### DIFF
--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.0"
 
   # Locked until https://github.com/fog/fog-google/issues/417 is resolved
-  spec.add_dependency "fog-core", "<= 2.3.0"
+  spec.add_dependency "fog-core", "<= 2.1.0"
   spec.add_dependency "fog-json", "~> 1.2"
   spec.add_dependency "fog-xml", "~> 0.1.0"
 


### PR DESCRIPTION
Reverts fog/fog-google#481 due to causing a regression around  https://github.com/fog/fog-google/pull/422

We need to push out a minor release before we can update that.