### PR TITLE
Make the ssh key operation synchronous in tests

### DIFF
--- a/test/integration/compute/core_compute/test_servers.rb
+++ b/test/integration/compute/core_compute/test_servers.rb
@@ -32,7 +32,7 @@ class TestServers < FogIntegrationTest
     key = "ssh-rsa IAMNOTAREALSSHKEYAMA=="
     username = "test_user"
     server = @factory.create
-    server.add_ssh_key(username, key)
+    server.add_ssh_key(username, key, false)
     assert_equal [{ :key => "ssh-keys",
                     :value => "test_user:ssh-rsa IAMNOTAREALSSHKEYAMA== test_user" }], server.metadata[:items]
   end


### PR DESCRIPTION
Fixing test flakiness.

It looks like adding ssh keys has become slower since we didn't notice this before.