### PR TITLE
Fog::Storage::GoogleJSON::File public/predefined_acl are not passed to api client

### DIFF
--- a/lib/fog/storage/google_json/models/file.rb
+++ b/lib/fog/storage/google_json/models/file.rb
@@ -105,7 +105,7 @@ module Fog
           
           options[:predefined_acl] ||= @predefined_acl
 
-          service.put_object(directory.key, key, body, options)
+          service.put_object(directory.key, key, body, predefined_acl: options.delete(:predefined_acl), options)
           self.content_length = Fog::Storage.get_body_size(body)
           self.content_type ||= Fog::Storage.get_content_type(body)
           true

--- a/lib/fog/storage/google_json/models/file.rb
+++ b/lib/fog/storage/google_json/models/file.rb
@@ -105,7 +105,7 @@ module Fog
           
           options[:predefined_acl] ||= @predefined_acl
 
-          service.put_object(directory.key, key, body, predefined_acl: options.delete(:predefined_acl), options)
+          service.put_object(directory.key, key, body, predefined_acl: options.delete(:predefined_acl), **options)
           self.content_length = Fog::Storage.get_body_size(body)
           self.content_type ||= Fog::Storage.get_content_type(body)
           true


### PR DESCRIPTION
After updating my application to `fog-google: 1.10` and ruby `2.7.1` I have noticed that even if my upstream code sets Storage object as public all my files are uploaded as a private one (without any ACL). 

I found out that the new Ruby version introduced [breaking changes for method arguments](https://rubyreferences.github.io/rubychanges/2.7.html#keyword-argument-related-changes). 

Change in PR fixes this issue, however, I am not sure if a similar problem is not happening in other places.


CC: @icco, @Temikus and @plribeiro3000