### PR TITLE
[StorageJSON] Add fallback URL signing mechanism via IAM SignBlob API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 # Fog custom enforced styles
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Style/ConditionalAssignment:
@@ -94,7 +94,7 @@ Naming/PredicateName:
   - is_
   - has_
   - have_
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
   - is_
   Exclude:
   - spec/**/*
@@ -246,7 +246,7 @@ Style/WhenThen:
 Lint/EachWithObjectArgument:
   Description: Check for immutable argument given to each_with_object.
   Enabled: true
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
   Enabled: false

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fog-json", "~> 1.2"
   spec.add_dependency "fog-xml", "~> 0.1.0"
 
-  # Hard Requirement as of 1.0
   spec.add_dependency "google-api-client", ">= 0.32", "< 0.34"
-  
+  spec.add_dependency "google-cloud-env", "~> 1.2"
+
   # Debugger
   spec.add_development_dependency "pry"
 

--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -1,3 +1,5 @@
+require "google-cloud-env"
+
 module Fog
   module Google
     module Shared
@@ -14,6 +16,9 @@ module Fog
         @project = project
         @api_version = api_version
         @api_url = base_url + api_version + "/projects/"
+        # google-cloud-env allows us to figure out which GCP runtime we're running in and query metadata
+        # e.g. whether we're running in GCE/GKE/AppEngine or what region the instance is running in
+        @google_cloud_env = ::Google::Cloud::Env.get
       end
 
       ##
@@ -33,14 +38,14 @@ module Fog
       def initialize_google_client(options)
         # NOTE: loaded here to avoid requiring this as a core Fog dependency
         begin
-          # Because of how Google API gem was rewritten, we get to do all sorts
-          # of funky things, like this nonsense.
+          # TODO: google-api-client is in gemspec now, re-assess if this initialization logic is still needed
           require "google/apis/monitoring_#{Fog::Google::Monitoring::GOOGLE_MONITORING_API_VERSION}"
           require "google/apis/compute_#{Fog::Compute::Google::GOOGLE_COMPUTE_API_VERSION}"
           require "google/apis/dns_#{Fog::DNS::Google::GOOGLE_DNS_API_VERSION}"
           require "google/apis/pubsub_#{Fog::Google::Pubsub::GOOGLE_PUBSUB_API_VERSION}"
           require "google/apis/sqladmin_#{Fog::Google::SQL::GOOGLE_SQL_API_VERSION}"
           require "google/apis/storage_#{Fog::Storage::GoogleJSON::GOOGLE_STORAGE_JSON_API_VERSION}"
+          require "google/apis/iamcredentials_#{Fog::Storage::GoogleJSON::GOOGLE_STORAGE_JSON_IAM_API_VERSION}"
           require "googleauth"
         rescue LoadError => error
           Fog::Errors::Error.new("Please install the google-api-client (>= 0.9) gem before using this provider")

--- a/lib/fog/storage/google_json.rb
+++ b/lib/fog/storage/google_json.rb
@@ -27,6 +27,10 @@ module Fog
       GOOGLE_STORAGE_JSON_BASE_URL = "https://www.googleapis.com/storage/".freeze
       GOOGLE_STORAGE_BUCKET_BASE_URL = "https://storage.googleapis.com/".freeze
 
+      # Version of IAM API used for blob signing, see Fog::Storage::GoogleJSON::Real#iam_signer
+      GOOGLE_STORAGE_JSON_IAM_API_VERSION = "v1".freeze
+      GOOGLE_STORAGE_JSON_IAM_API_SCOPE_URLS = %w(https://www.googleapis.com/auth/devstorage.full_control).freeze
+
       # TODO: Come up with a way to only request a subset of permissions.
       # https://cloud.google.com/storage/docs/json_api/v1/how-tos/authorizing
       GOOGLE_STORAGE_JSON_API_SCOPE_URLS = %w(https://www.googleapis.com/auth/devstorage.full_control).freeze

--- a/lib/fog/storage/google_json/mock.rb
+++ b/lib/fog/storage/google_json/mock.rb
@@ -10,10 +10,16 @@ module Fog
         def initialize(options = {})
           shared_initialize(options[:google_project], GOOGLE_STORAGE_JSON_API_VERSION, GOOGLE_STORAGE_JSON_BASE_URL)
           @client = MockClient.new('test')
+          @storage_json = MockClient.new('test')
+          @iam_service = MockClient.new('test')
         end
 
         def signature(_params)
           "foo"
+        end
+
+        def google_access_id
+          "my-account@project.iam.gserviceaccount"
         end
       end
     end

--- a/lib/fog/storage/google_json/real.rb
+++ b/lib/fog/storage/google_json/real.rb
@@ -13,7 +13,14 @@ module Fog
           options[:google_api_scope_url] = GOOGLE_STORAGE_JSON_API_SCOPE_URLS.join(" ")
           @host = options[:host] || "storage.googleapis.com"
 
+          # TODO(temikus): Do we even need this client?
           @client = initialize_google_client(options)
+          # IAM client used for SignBlob API
+          @iam_service = ::Google::Apis::IamcredentialsV1::IAMCredentialsService.new
+          apply_client_options(@iam_service, {
+                                 google_api_scope_url: GOOGLE_STORAGE_JSON_IAM_API_SCOPE_URLS.join(" ")
+                               })
+
           @storage_json = ::Google::Apis::StorageV1::StorageService.new
           apply_client_options(@storage_json, options)
 
@@ -56,11 +63,107 @@ DATA
           canonical_resource.chop!
           string_to_sign << canonical_resource.to_s
 
-          key = OpenSSL::PKey::RSA.new(@client.signing_key)
-          digest = OpenSSL::Digest::SHA256.new
-          signed_string = key.sign(digest, string_to_sign)
+          # TODO(temikus): make signer configurable or add ability to supply your own via lambda
+          if !@storage_json.authorization.signing_key.nil?
+            signed_string = default_signer(string_to_sign)
+          else
+            # If client doesn't contain signing key attempt to auth via IAM SignBlob API
+            signed_string = iam_signer(string_to_sign)
+          end
 
           Base64.encode64(signed_string).chomp!
+        end
+
+        private
+
+        def google_access_id
+          @google_access_id ||= get_google_access_id
+        end
+
+        ##
+        # Fetches the google service account name
+        #
+        # @return [String] Service account name, typically needed for GoogleAccessId, e.g.
+        #   my-account@project.iam.gserviceaccount
+        # @raises [Fog::Errors::Error] If authorisation is incorrect or inapplicable for current action
+        def get_google_access_id
+          if @storage_json.authorization.is_a?(::Google::Auth::UserRefreshCredentials)
+            raise Fog::Errors::Error.new("User / Application Default Credentials are not supported for storage"\
+                                         "url signing, please use a service account or metadata authentication.")
+          end
+
+          if !@storage_json.authorization.issuer.nil?
+            return @storage_json.authorization.issuer
+          else
+            get_access_id_from_metadata
+          end
+        end
+
+        ##
+        # Attempts to fetch the google service account name from metadata using Google::Cloud::Env
+        #
+        # @return [String] Service account name, typically needed for GoogleAccessId, e.g.
+        #   my-account@project.iam.gserviceaccount
+        # @raises [Fog::Errors::Error] If Metadata service is not available or returns an invalid response
+        def get_access_id_from_metadata
+          if @google_cloud_env.metadata?
+            access_id = @google_cloud_env.lookup_metadata("instance", "service-accounts/default/email")
+          else
+            raise Fog::Errors::Error.new("Metadata service not available, unable to retrieve service account info.")
+          end
+
+          if access_id.nil?
+            raise Fog::Errors::Error.new("Metadata service found but didn't return data." \
+               "Please file a bug: https://github.com/fog/fog-google")
+          end
+
+          return access_id
+        end
+
+        ##
+        # Default url signer using service account keys
+        #
+        # @param [String] string_to_sign Special collection of headers and options for V2 storage signing, e.g.:
+        #
+        #   StringToSign = HTTP_Verb + "\n" +
+        #                  Content_MD5 + "\n" +
+        #                  Content_Type + "\n" +
+        #                  Expires + "\n" +
+        #                  Canonicalized_Extension_Headers +
+        #                  Canonicalized_Resource
+        #
+        #   See https://cloud.google.com/storage/docs/access-control/signed-urls-v2
+        # @return [String] Signature binary blob
+        def default_signer(string_to_sign)
+          key = OpenSSL::PKey::RSA.new(@storage_json.authorization.signing_key)
+          digest = OpenSSL::Digest::SHA256.new
+          return key.sign(digest, string_to_sign)
+        end
+
+        ##
+        # Fallback URL signer using the IAM SignServiceAccountBlob API, see
+        #   Google::Apis::IamcredentialsV1::IAMCredentialsService#sign_service_account_blob
+        #
+        # @param [String] string_to_sign Special collection of headers and options for V2 storage signing, e.g.:
+        #
+        #   StringToSign = HTTP_Verb + "\n" +
+        #                  Content_MD5 + "\n" +
+        #                  Content_Type + "\n" +
+        #                  Expires + "\n" +
+        #                  Canonicalized_Extension_Headers +
+        #                  Canonicalized_Resource
+        #
+        #   See https://cloud.google.com/storage/docs/access-control/signed-urls-v2
+        # @return [String] Signature binary blob
+        def iam_signer(string_to_sign)
+          request = {
+            "payload": string_to_sign
+          }
+
+          resource = "projects/-/serviceAccounts/#{google_access_id}"
+          response = @iam_service.sign_service_account_blob resource, request, {}
+
+          return response.signed_blob
         end
       end
     end

--- a/lib/fog/storage/google_json/utils.rb
+++ b/lib/fog/storage/google_json/utils.rb
@@ -27,7 +27,7 @@ module Fog
             query = filtered.map { |k, v| [k.to_s, Fog::Google.escape(v)].join("=") }
           end
 
-          query << "GoogleAccessId=#{@client.issuer}"
+          query << "GoogleAccessId=#{google_access_id}"
           query << "Signature=#{CGI.escape(signature(params))}"
           query << "Expires=#{params[:headers]['Date']}"
           "#{params[:host]}/#{params[:path]}?#{query.join('&')}"

--- a/lib/fog/storage/google_xml/requests/get_bucket.rb
+++ b/lib/fog/storage/google_xml/requests/get_bucket.rb
@@ -1,4 +1,3 @@
-require "pp"
 module Fog
   module Storage
     class GoogleXML

--- a/tasks/changelog.rake
+++ b/tasks/changelog.rake
@@ -20,11 +20,18 @@ end
 
 # Extracts all changes that have been made after the latest pushed tag
 def changes_since_last_tag
-  `git --no-pager log $(git describe --tags --abbrev=0)..HEAD --oneline`
+  `git --no-pager log $(git describe --tags --abbrev=0)..HEAD --grep="Merge" --pretty=format:"%t - %s%n%b%n"`
+end
+
+# Extracts all github users contributed since last tag
+def users_since_last_tag
+  `git --no-pager log $(git describe --tags --abbrev=0)..HEAD --grep="Merge" --pretty=format:"%s" | cut -d' ' -f 6 | cut -d/ -f1 | uniq`
 end
 
 namespace :changelog do
   task :generate do
     insert_after_line("CHANGELOG.md", changes_since_last_tag, /^## Next/)
+    printf("Users contributed since last release:\n")
+    printf(users_since_last_tag)
   end
 end


### PR DESCRIPTION
This option is added to enable metadata-authenticated workloads, like GKE WorkloadIdentity or GCE Instance metadata auth

- Added a secondary fallback signer to StorageJSON
- Refactored the signing process a bit to simplify logic and provide a more user-friendly experience in case of issues
- Added `google-cloud-env` support to the shared initialise so all modules can use it

Fixes #502 