### PR TITLE
Make insert_server support ShieldedInstanceConfig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-    - rvm: 2.3
     - rvm: 2.4
     - rvm: 2.5
     - rvm: 2.6
-    - rvm: jruby-9.1
+    - rvm: 2.7
+    - rvm: jruby-9.2
     - rvm: jruby-head
     - rvm: truffleruby-head
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The main maintainers for the Google sections are @icco, @Temikus and @plribeiro3
 
 - As of **v1.0.0**, fog-google includes google-api-client as a dependency, there is no need to include it separately anymore.
 
-- Fog-google is currently supported on Ruby 2.3+ See [supported ruby versions](#supported-ruby-versions) for more info.
+- Fog-google is currently supported on Ruby 2.4+ See [supported ruby versions](#supported-ruby-versions) for more info.
 
 See **[MIGRATING.md](MIGRATING.md)** for migration between major versions.
 
@@ -27,8 +27,8 @@ As of 2017-12-15, we are still working on making Fog for Google Compute engine (
 
 ## SQL
 
-Fog implements [v1beta4](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/) of the Google Cloud SQL Admin API. As of 2017-11-06, Cloud SQL is mostly feature-complete. Please [file issues](https://github.com/fog/fog-google/issues) for any anomalies you see or features you would like as we finish 
-adding remaining features. 
+Fog implements [v1beta4](https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/) of the Google Cloud SQL Admin API. As of 2017-11-06, Cloud SQL is mostly feature-complete. Please [file issues](https://github.com/fog/fog-google/issues) for any anomalies you see or features you would like as we finish
+adding remaining features.
 
 ## DNS
 
@@ -36,8 +36,8 @@ Fog implements [v1](https://cloud.google.com/dns/api/v1/) of the Google Cloud DN
 
 ## Monitoring
 
-Fog implements [v3](https://cloud.google.com/monitoring/api/v3/) of the Google Cloud Monitoring API. As of 2017-10-05, we believe Fog for Google Cloud Monitoring is feature complete for metric-related resources and are working on supporting groups. 
- 
+Fog implements [v3](https://cloud.google.com/monitoring/api/v3/) of the Google Cloud Monitoring API. As of 2017-10-05, we believe Fog for Google Cloud Monitoring is feature complete for metric-related resources and are working on supporting groups.
+
 We are always looking for people to improve our code and test coverage, so please [file issues](https://github.com/fog/fog-google/issues) for any anomalies you see or features you would like.
 
 ## Pubsub
@@ -94,12 +94,12 @@ cat .fog.example >> ~/.fog # appends the sample configuration
 vim ~/.fog                 # edit file with yout config
 ```
 
-As of `1.9.0` fog-google supports Google [application default credentials (ADC)](https://cloud.google.com/docs/authentication/production) 
+As of `1.9.0` fog-google supports Google [application default credentials (ADC)](https://cloud.google.com/docs/authentication/production)
 The auth method uses [Google::Auth.get_application_default](https://www.rubydoc.info/gems/googleauth/0.6.7/Google%2FAuth.get_application_default)
 under the hood.
 
 Example workflow for a GCE instance with [service account scopes](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances)
-defined: 
+defined:
 
 ```
 > connection = Fog::Compute::Google.new(:google_project => "my-project", :google_application_default => true)
@@ -165,10 +165,10 @@ $ bundle exec pry
 
 ## Supported Ruby Versions
 
-Fog-google is currently supported on Ruby 2.3+.
+Fog-google is currently supported on Ruby 2.4+.
 
 In general we support (and run our CI) for Ruby versions that are actively supported
-by Ruby Core - that is, Ruby versions that are not end of life. Older versions of 
+by Ruby Core - that is, Ruby versions that are not end of life. Older versions of
 Ruby _may_ still work, but are unsupported and not recommended. See https://www.ruby-lang.org/en/downloads/branches/
 for details about the Ruby support schedule.
 

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fog-json", "~> 1.2"
   spec.add_dependency "fog-xml", "~> 0.1.0"
 
-  spec.add_dependency "google-api-client", ">= 0.32", "< 0.34"
+  spec.add_dependency "google-api-client", ">= 0.44.2", "< 0.51"
   spec.add_dependency "google-cloud-env", "~> 1.2"
 
   # Debugger

--- a/lib/fog/compute/google/requests/insert_server.rb
+++ b/lib/fog/compute/google/requests/insert_server.rb
@@ -100,6 +100,10 @@ module Fog
             data[:scheduling] = ::Google::Apis::ComputeV1::Scheduling.new(options[:scheduling])
           end
 
+          if data[:shielded_instance_config]
+            data[:shielded_instance_config] = ::Google::Apis::ComputeV1::ShieldedInstanceConfig.new(options[:shielded_instance_config])
+          end
+
           if data[:tags]
             if options[:tags].is_a?(Array)
               # Process classic tag notation, i.e. ["fog"]

--- a/lib/fog/google/requests/sql/delete_user.rb
+++ b/lib/fog/google/requests/sql/delete_user.rb
@@ -8,7 +8,7 @@ module Fog
 
       class Real
         def delete_user(instance_id, host, name)
-          @sql.delete_user(@project, instance_id, host, name)
+          @sql.delete_user(@project, instance_id, host: host, name: name)
         end
       end
 


### PR DESCRIPTION
google-api-client support `shielded_instance_config` since 0.44.2
googleapis/google-api-ruby-client@9678faba19830db0671870acca86794fbc83cb42

It is used to create GCE instances with "Shielded VM" feature
https://cloud.google.com/security/shielded-cloud/shielded-vm