### PR TITLE
Upgrade CI docker image to Ubuntu 18.04

### DIFF
--- a/ci/docker-image/Dockerfile
+++ b/ci/docker-image/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
-# Packages
+# Common dependencies for the CI env and gems with C extensions
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y -qq update && apt-get -y -qq install \
   build-essential \
   curl \
@@ -12,7 +12,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y -qq update && apt-get -y -qq insta
   libxml2-dev \
   libxslt-dev
 
-# Ubuntu 16.04 will fetch us 2.3.x without any issues.
+# Ubuntu 18.04 will fetch us Ruby 2.5.x
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y -qq install ruby ruby-dev && apt-get clean
 
 RUN gem install bundler


### PR DESCRIPTION
Primary purpose of the upgrade is newer ruby since 2.3 is EOL which is causing issues on #509 

This will force 2.5 to be installed which is enough for our integration pipeline purposes.
TravisCI will still continue to run all non-EOL'ed rubies so we should see compatibility issues if they arise.