### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,23 @@ matrix:
     - rvm: jruby-9.2
     - rvm: jruby-head
     - rvm: truffleruby-head
+ # ppc64le support code
+    - rvm: 2.4
+      arch: ppc64le
+    - rvm: 2.5
+      arch: ppc64le
+    - rvm: 2.6
+      arch: ppc64le
+    - rvm: 2.7
+      arch: ppc64le
+    - rvm: jruby-9.2
+      arch: ppc64le
+    - rvm: jruby-head
+      arch: ppc64le
   allow_failures:
     - rvm: jruby-head
     - rvm: truffleruby-head
+    - rvm: jruby-head
+      arch: ppc64le
 notifications:
   email: false


### PR DESCRIPTION
Added support for architecture ppc64le.  This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. 
The build and test results are available at the below location.
https://travis-ci.com/github/nageshlop/fog-google/builds/209012503