### PR TITLE
Ruby 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - rvm: 2.5
     - rvm: 2.6
     - rvm: 2.7
+    - rvm: 3.0
     - rvm: jruby-9.2
     - rvm: jruby-head
     - rvm: truffleruby-head
@@ -19,6 +20,8 @@ matrix:
     - rvm: 2.6
       arch: ppc64le
     - rvm: 2.7
+      arch: ppc64le
+    - rvm: 3.0
       arch: ppc64le
     - rvm: jruby-9.2
       arch: ppc64le

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ $ bundle exec pry
 
 ## Supported Ruby Versions
 
-Fog-google is currently supported on Ruby 2.4+.
+Fog-google is currently supported on Ruby 2.4+ and 3.0+.
 
 In general we support (and run our CI) for Ruby versions that are actively supported
 by Ruby Core - that is, Ruby versions that are not end of life. Older versions of

--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # As of 0.1.1
-  spec.required_ruby_version = "~> 2.0"
+  spec.required_ruby_version = ">= 2.0"
 
   # Locked until https://github.com/fog/fog-google/issues/417 is resolved
   spec.add_dependency "fog-core", "<= 2.1.0"

--- a/lib/fog/storage/google_json/utils.rb
+++ b/lib/fog/storage/google_json/utils.rb
@@ -19,7 +19,7 @@ module Fog
 
         def host_path_query(params, expires)
           params[:headers]["Date"] = expires.to_i
-          params[:path] = URI.encode(params[:path]).gsub("%2F", "/")
+          params[:path] = CGI.escape(params[:path]).gsub("%2F", "/").gsub("+", "%20")
           query = []
 
           if params[:query]


### PR DESCRIPTION
Mostly just bumping the version support, but also updated reference to `URI.encode` which was deprecated and now removed.