### PR TITLE
Stop using obsoleted URI.encode method

### DIFF
--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "google-api-client", ">= 0.44.2", "< 0.51"
   spec.add_dependency "google-cloud-env", "~> 1.2"
 
+  spec.add_dependency "addressable", ">= 2.7.0"
+
   # Debugger
   spec.add_development_dependency "pry"
 

--- a/lib/fog/storage/google_json/utils.rb
+++ b/lib/fog/storage/google_json/utils.rb
@@ -1,3 +1,5 @@
+require 'addressable'
+
 module Fog
   module Storage
     class GoogleJSON
@@ -19,7 +21,7 @@ module Fog
 
         def host_path_query(params, expires)
           params[:headers]["Date"] = expires.to_i
-          params[:path] = URI.encode(params[:path]).gsub("%2F", "/")
+          params[:path] = ::Addressable::URI.encode_component(params[:path], Addressable::URI::CharacterClasses::PATH)
           query = []
 
           if params[:query]


### PR DESCRIPTION
`URI.encode` has been marked obsolete and has been removed from Ruby v3.0.
We use the addressable gem to properly escape the path parameter.