### PR TITLE
Support passing object properties to #copy_object

### DIFF
--- a/lib/fog/storage/google_json/requests/copy_object.rb
+++ b/lib/fog/storage/google_json/requests/copy_object.rb
@@ -15,9 +15,19 @@ module Fog
                         target_bucket, target_object, options = {})
           request_options = ::Google::Apis::RequestOptions.default.merge(options)
 
+          object = ::Google::Apis::StorageV1::Object.new(options)
+
           @storage_json.copy_object(source_bucket, source_object,
                                     target_bucket, target_object,
-                                    request_options, **options)
+                                    object, options: request_options, **filter_keyword_args(options))
+        end
+
+        private
+
+        def filter_keyword_args(options)
+          method = @storage_json.method(:copy_object)
+          allowed = method.parameters.filter { |param| %i(key keyreq).include?(param[0]) }.map { |param| param[1] }.compact
+          options.filter { |key, _| allowed.include?(key) }
         end
       end
 

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -113,6 +113,26 @@ class TestStorageRequests < StorageShared
     assert_kind_of(Net::HTTPOK, response)
   end
 
+  def test_copy_object_with_request_options
+    assert_raises(Google::Apis::AuthorizationError) do
+      target_object_name = new_object_name
+
+      @client.copy_object(some_bucket_name, some_object_name,
+                          some_bucket_name, target_object_name, authorization: false)
+    end
+  end
+
+  def test_copy_object_with_object_property
+    target_object_name = new_object_name
+
+    @client.copy_object(some_bucket_name, some_object_name,
+                        some_bucket_name, target_object_name, content_type: 'text/plain')
+
+    object = @client.get_object(some_bucket_name, target_object_name)
+
+    assert_equal("text/plain", object[:content_type])
+  end
+
   def test_list_objects
     expected_object = some_object_name
 


### PR DESCRIPTION
This PR adds ability to pass [object properties](https://cloud.google.com/storage/docs/json_api/v1/objects?hl=en#resource) like `content_type` on copying Storage objects. At the same time, it also fixes the issue with request_options not being passed properly and having no effect, while taking care of the change in #513 to work as before.

This is needed to fix carrierwaveuploader/carrierwave#2533.