### PR TITLE
Fix Ruby 3.0 kwargs failures

### DIFF
--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -87,8 +87,7 @@ module Fog
       # Applies given options to the client instance
       #
       # @param [Google::Apis::Core::BaseService] service API service client instance
-      # @param [Hash] google_client_options Service client options to apply
-      # @param [Hash] _ignored Rest of the options (for convenience, ignored)
+      # @param [Hash] options (all ignored a.t.m., except :google_client_options)
       # @return [void]
       def apply_client_options(service, options = {})
         google_client_options = options[:google_client_options]

--- a/lib/fog/storage/google_json/models/directories.rb
+++ b/lib/fog/storage/google_json/models/directories.rb
@@ -5,7 +5,7 @@ module Fog
         model Fog::Storage::GoogleJSON::Directory
 
         def all(opts = {})
-          data = service.list_buckets(opts).to_h[:items] || []
+          data = service.list_buckets(**opts).to_h[:items] || []
           load(data)
         end
 

--- a/lib/fog/storage/google_json/models/directory.rb
+++ b/lib/fog/storage/google_json/models/directory.rb
@@ -52,7 +52,7 @@ module Fog
 
         def save
           requires :key
-          service.put_bucket(key, attributes)
+          service.put_bucket(key, **attributes)
           true
         end
       end

--- a/lib/fog/storage/google_json/models/file.rb
+++ b/lib/fog/storage/google_json/models/file.rb
@@ -105,7 +105,7 @@ module Fog
           
           options[:predefined_acl] ||= @predefined_acl
 
-          service.put_object(directory.key, key, body, options)
+          service.put_object(directory.key, key, body, **options)
           self.content_length = Fog::Storage.get_body_size(body)
           self.content_type ||= Fog::Storage.get_content_type(body)
           true

--- a/lib/fog/storage/google_json/models/files.rb
+++ b/lib/fog/storage/google_json/models/files.rb
@@ -33,7 +33,7 @@ module Fog
 
         def get(key, options = {}, &block)
           requires :directory
-          data = service.get_object(directory.key, key, options, &block).to_h
+          data = service.get_object(directory.key, key, **options, &block).to_h
           new(data)
         rescue ::Google::Apis::ClientError => e
           raise e unless e.status_code == 404

--- a/lib/fog/storage/google_json/requests/get_object.rb
+++ b/lib/fog/storage/google_json/requests/get_object.rb
@@ -53,11 +53,11 @@ module Fog
             :options => request_options
           }
 
-          object = @storage_json.get_object(bucket_name, object_name, all_opts).to_h
+          object = @storage_json.get_object(bucket_name, object_name, **all_opts).to_h
           @storage_json.get_object(
             bucket_name,
             object_name,
-            all_opts.merge(:download_dest => buf.path)
+            **all_opts.merge(:download_dest => buf.path)
           )
 
           if block_given?

--- a/lib/fog/storage/google_json/requests/list_buckets.rb
+++ b/lib/fog/storage/google_json/requests/list_buckets.rb
@@ -11,10 +11,10 @@ module Fog
                          prefix: nil, projection: nil)
           @storage_json.list_buckets(
             @project,
-            :max_results => max_results,
-            :page_token => page_token,
-            :prefix => prefix,
-            :projection => projection
+            max_results: max_results,
+            page_token: page_token,
+            prefix: prefix,
+            projection: projection
           )
         end
       end

--- a/lib/fog/storage/google_json/requests/list_objects.rb
+++ b/lib/fog/storage/google_json/requests/list_objects.rb
@@ -31,7 +31,7 @@ module Fog
 
           @storage_json.list_objects(
             bucket,
-            options.select { |k, _| allowed_opts.include? k }
+            **options.select { |k, _| allowed_opts.include? k }
           )
         end
       end

--- a/lib/fog/storage/google_json/requests/put_bucket.rb
+++ b/lib/fog/storage/google_json/requests/put_bucket.rb
@@ -19,7 +19,7 @@ module Fog
                        predefined_default_object_acl: nil,
                        **options)
           bucket = ::Google::Apis::StorageV1::Bucket.new(
-            options.merge(:name => bucket_name)
+            **options.merge(:name => bucket_name)
           )
 
           @storage_json.insert_bucket(

--- a/lib/fog/storage/google_json/requests/put_bucket_acl.rb
+++ b/lib/fog/storage/google_json/requests/put_bucket_acl.rb
@@ -12,7 +12,7 @@ module Fog
           raise ArgumentError.new("bucket_name is required") unless bucket_name
           raise ArgumentError.new("acl is required") unless acl
 
-          acl_update = ::Google::Apis::StorageV1::BucketAccessControl.new(acl)
+          acl_update = ::Google::Apis::StorageV1::BucketAccessControl.new(**acl)
           @storage_json.insert_bucket_access_control(bucket_name, acl_update)
         end
       end

--- a/lib/fog/storage/google_json/requests/put_object.rb
+++ b/lib/fog/storage/google_json/requests/put_object.rb
@@ -51,7 +51,7 @@ module Fog
           data, options = normalize_data(data, options)
 
           object_config = ::Google::Apis::StorageV1::Object.new(
-            options.merge(:name => object_name)
+            **options.merge(:name => object_name)
           )
 
           @storage_json.insert_object(

--- a/lib/fog/storage/google_json/requests/put_object_acl.rb
+++ b/lib/fog/storage/google_json/requests/put_object_acl.rb
@@ -15,7 +15,7 @@ module Fog
           raise ArgumentError.new("object_name is required") unless object_name
           raise ArgumentError.new("acl is required") unless acl
 
-          acl_object = ::Google::Apis::StorageV1::ObjectAccessControl.new(acl)
+          acl_object = ::Google::Apis::StorageV1::ObjectAccessControl.new(**acl)
 
           @storage_json.insert_object_access_control(
             bucket_name, object_name, acl_object

--- a/lib/fog/storage/google_xml/models/file.rb
+++ b/lib/fog/storage/google_xml/models/file.rb
@@ -109,7 +109,7 @@ module Fog
           options["Expires"] = expires if expires
           options.merge!(metadata)
 
-          data = service.put_object(directory.key, key, body, options)
+          data = service.put_object(directory.key, key, body, **options)
           merge_attributes(data.headers.reject { |key, _value| ["Content-Length", "Content-Type"].include?(key) })
           self.content_length = Fog::Storage.get_body_size(body)
           self.content_type ||= Fog::Storage.get_content_type(body)


### PR DESCRIPTION
This makes `bundle exec rake test:storage` pass for both Ruby 2.7.2 and
3.0.0.

```
TestStorageRequests

  test_directories_destroy                                        PASS (2.16s)
  test_directories_put                                            PASS (0.71s)
  test_put_object_predefined_acl                                  PASS (1.51s)
  test_delete_object                                              PASS (1.73s)
  test_directory_files                                            PASS (1.80s)
  test_list_object_acl                                            PASS (1.46s)
  test_directory_public_url                                       PASS (0.84s)
  test_put_object_contradictory_content_type                      PASS (1.61s)
  test_object_metadata                                            PASS (1.65s)
  test_files_public_url                                           PASS (1.75s)
  test_copy_object_predefined_acl                                 PASS (8.68s)
  test_files_get                                                  PASS (2.04s)
  test_list_buckets                                               PASS (1.49s)
  test_files_destroy                                              PASS (2.29s)
  test_files_get_https_url                                        PASS (1.10s)
  test_put_bucket_acl                                             PASS (1.39s)
  test_put_object_nil                                             PASS (0.67s)
  test_directories_put_invalid_predefined_acl                     PASS (0.17s)
  test_delete_bucket                                              PASS (1.27s)
  test_get_object                                                 PASS (1.83s)
  test_put_object_paperclip                                       PASS (2.48s)
  test_get_bucket                                                 PASS (4.79s)
  test_files_all                                                  PASS (1.70s)
  test_get_bucket_acl                                             PASS (1.51s)
  test_get_object_https_url                                       PASS (1.57s)
  test_put_object_invalid_predefined_acl                          PASS (0.77s)
  test_files_set_body_file                                        PASS (2.73s)
  test_files_copy                                                 PASS (2.73s)
  test_list_bucket_acl                                            PASS (1.51s)
  test_get_object_http_url                                        PASS (1.59s)
  test_put_object_url                                             PASS (0.74s)
  test_put_bucket                                                 PASS (1.56s)
  test_files_create_invalid_predefined_acl                        PASS (1.71s)
  test_put_object_string                                          PASS (1.64s)
  test_files_set_body_string                                      PASS (2.77s)
  test_files_create_predefined_acl                                PASS (1.56s)
  test_files_create_string                                        PASS (1.73s)
  test_directories_get                                            PASS (1.00s)
  test_directories_put_predefined_acl                             PASS (0.75s)
  test_copy_object                                                PASS (1.95s)
  test_files_create_file                                          PASS (1.91s)
  test_put_bucket_predefined_acl                                  PASS (0.73s)
  test_files_metadata                                             PASS (7.90s)
  test_get_object_acl                                             PASS (1.64s)
  test_put_bucket_invalid_predefined_acl                          PASS (0.23s)
  test_directories_all                                            PASS (2.29s)
  test_list_objects                                               PASS (1.58s)
  test_put_object_file                                            PASS (1.71s)
  test_put_object_acl                                             PASS (1.74s)
  test_files_each                                                 PASS (1.76s)
  test_files_get_https_url_whitespace                             PASS (0.80s)

Finished in 95.19968s
51 tests, 62 assertions, 0 failures, 0 errors, 0 skips
```