### PR TITLE
Fix Ruby 3.0 kwargs error in `#copy_object`

### DIFF
--- a/lib/fog/storage/google_json/requests/copy_object.rb
+++ b/lib/fog/storage/google_json/requests/copy_object.rb
@@ -15,7 +15,7 @@ module Fog
                         target_bucket, target_object, options = {})
           request_options = ::Google::Apis::RequestOptions.default.merge(options)
 
-          object = ::Google::Apis::StorageV1::Object.new(options)
+          object = ::Google::Apis::StorageV1::Object.new(**options)
 
           @storage_json.copy_object(source_bucket, source_object,
                                     target_bucket, target_object,


### PR DESCRIPTION
refs: https://github.com/fog/fog-google/commit/08fe0c9ec966e26e9760f01466a7f108bbb7d770#diff-0ff494c60559cd861720e6b0c68e4142e68b5b72a3f962eb6e17d5f432ba756aR18

Focusing on `#copy_object` related tests, they passes on both Ruby 2.7.3 and 3.0.1

```
% bundle exec rake test TEST=test/integration/storage/test_objects.rb
Started with run options --seed 30880

TestStorageRequests
  test_copy_object_with_request_options                           PASS (2.30s)
  test_copy_object_predefined_acl                                 PASS (1.02s)
  test_copy_object                                                PASS (0.85s)
  test_copy_object_with_object_property                           PASS (0.88s)

Finished in 5.04669s
4 tests, 4 assertions, 0 failures, 0 errors, 0 skips
```