### PR TITLE
Unescape slashes in urls

### DIFF
--- a/lib/fog/storage/google_json/utils.rb
+++ b/lib/fog/storage/google_json/utils.rb
@@ -20,9 +20,10 @@ module Fog
         def host_path_query(params, expires)
           params[:headers]["Date"] = expires.to_i
           # implementation from CGI.escape, but without ' ' to  '+' conversion
-          params[:path] = params[:path].b.gsub(/([^a-zA-Z0-9_.\-~]+)/) do |m|
+          params[:path] = params[:path].b.gsub(/([^a-zA-Z0-9_.\-~]+)/) { |m|
             '%' + m.unpack('H2' * m.bytesize).join('%').upcase
-          end
+          }.gsub("%2F", "/")
+
           query = []
 
           if params[:query]

--- a/test/unit/storage/test_json_requests.rb
+++ b/test/unit/storage/test_json_requests.rb
@@ -41,4 +41,12 @@ class UnitTestJsonRequests < MiniTest::Test
     assert_match(/just%20some%20file\.json/, url,
                  "space should be escaped with '%20'")
   end
+
+  def test_unescaped_slashes_in_url
+    url = @client.get_object_https_url("bucket",
+                                      "a/b/c.ext",
+                                      Time.now + 2 * 60)
+    assert_match(/a\/b\/c/, url,
+                 "slashes should not be escaped with '%2F'")
+  end
 end


### PR DESCRIPTION
After updating the gem to v1.13.0, I noticed a minor regression introduced in https://github.com/fog/fog-google/pull/517,  which broke using Paperclip for us. The reason being, that `.gsub("%2F", "/")` is not done after the code that replaces the deprecated `URI.encode` method. 

The code that replaces `URI.encode` does return `%2` instead of `/`.
`'a/b/c'.b.gsub(/([^a-zA-Z0-9_.\-~]+)/) { |m| '%' + m.unpack('H2' * m.bytesize).join('%').upcase }` returns `a%2Fb%2Fc`

The in the [PR](https://github.com/fog/fog-google/pull/517) mentioned [addressable gem](https://github.com/sporkmonger/addressable) also does not:
`Addressable::URI.encode_component('a/b/c', Addressable::URI::CharacterClasses::PATH)` returns `a/b/c`

This PR just adds back `.gsub("%2F", "/")` to fix the regression.