### PR TITLE
Fix get_object not working with binary files

### DIFF
--- a/lib/fog/storage/google_json/requests/get_object.rb
+++ b/lib/fog/storage/google_json/requests/get_object.rb
@@ -39,6 +39,7 @@ module Fog
           raise ArgumentError.new("object_name is required") unless object_name
 
           buf = Tempfile.new("fog-google-storage-temp")
+          buf.binmode
           buf.unlink
 
           # Two requests are necessary, first for metadata, then for content.

--- a/test/integration/storage/storage_shared.rb
+++ b/test/integration/storage/storage_shared.rb
@@ -86,9 +86,14 @@ class StorageShared < FogIntegrationTest
     "hello world"
   end
 
-  def some_temp_file
+  def binary_file_content
+    "PK\x03\x04\x14\x00\x00\x00\b\x00\x18\x89\x8AM\xE7!\xB7\x1C\x1C\x15j\x00\xB4\xB9".force_encoding(Encoding::ASCII_8BIT)
+  end
+
+  def some_temp_file(content = temp_file_content)
     @some_temp_file ||= Tempfile.new("fog-google-storage").tap do |t|
-      t.write(temp_file_content)
+      t.binmode
+      t.write(content)
       t.close
     end
     File.open(@some_temp_file.path, "r")

--- a/test/integration/storage/test_objects.rb
+++ b/test/integration/storage/test_objects.rb
@@ -34,13 +34,15 @@ class TestStorageRequests < StorageShared
 
   def test_put_object_paperclip
     object_name = new_object_name
-    paperclip_file = OpenStruct.new(:path => some_temp_file,
+    paperclip_file = OpenStruct.new(:path => some_temp_file(binary_file_content),
                                     :content_type => "image/png")
     @client.put_object(some_bucket_name, object_name, paperclip_file, :content_type => "image/png")
 
     object = @client.get_object(some_bucket_name, object_name)
 
     assert_equal(object_name, object[:name])
+    assert_equal(Encoding::ASCII_8BIT, object[:body].encoding)
+    assert_equal(binary_file_content, object[:body])
     assert_equal("image/png", object[:content_type])
   end
 


### PR DESCRIPTION
The change in #521 caused the `Tempfile` buffer to be used, which opens
a file in ASCII mode by default. We need to make use of `binmode` to
activate binary streams.

Closes https://github.com/fog/fog-google/issues/533