### PR TITLE
Attempt to fix kwargs issues on 2.6

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.6', '2.7', '3.0' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -39,7 +39,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.6', '2.7', '3.0' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -66,7 +66,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.6', '2.7', '3.0' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -93,7 +93,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.6', '2.7', '3.0' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -120,7 +120,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.6', '2.7', '3.0' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -147,7 +147,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.6', '2.7', '3.0' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -174,7 +174,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.6', '2.7', '3.0' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -201,7 +201,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.6', '2.7', '3.0' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 


### PR DESCRIPTION
Because apparently 2.6 vs 2.7 has some issues in terms of how it processes things like `**options`

This is needed to fix #535 