### PR TITLE
Symbolize keys so we don't break Paperclip on Ruby 2.6

### DIFF
--- a/lib/fog/storage/google_json/models/file.rb
+++ b/lib/fog/storage/google_json/models/file.rb
@@ -105,7 +105,9 @@ module Fog
           
           options[:predefined_acl] ||= @predefined_acl
 
-          service.put_object(directory.key, key, body, **options)
+          # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+          # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+          service.put_object(directory.key, key, body, **options.transform_keys(&:to_sym))
           self.content_length = Fog::Storage.get_body_size(body)
           self.content_type ||= Fog::Storage.get_content_type(body)
           true

--- a/lib/fog/storage/google_json/models/files.rb
+++ b/lib/fog/storage/google_json/models/files.rb
@@ -33,7 +33,9 @@ module Fog
 
         def get(key, options = {}, &block)
           requires :directory
-          data = service.get_object(directory.key, key, **options, &block).to_h
+          # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+          # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+          data = service.get_object(directory.key, key, **options.transform_keys(&:to_sym), &block).to_h
           new(data)
         rescue ::Google::Apis::ClientError => e
           raise e unless e.status_code == 404
@@ -42,12 +44,16 @@ module Fog
 
         def get_https_url(key, expires, options = {})
           requires :directory
-          service.get_object_https_url(directory.key, key, expires, **options)
+          # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+          # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+          service.get_object_https_url(directory.key, key, expires, **options.transform_keys(&:to_sym))
         end
 
         def metadata(key, options = {})
           requires :directory
-          data = service.get_object_metadata(directory.key, key, **options).to_h
+          # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+          # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+          data = service.get_object_metadata(directory.key, key, **options.transform_keys(&:to_sym)).to_h
           new(data)
         rescue ::Google::Apis::ClientError
           nil

--- a/lib/fog/storage/google_json/requests/copy_object.rb
+++ b/lib/fog/storage/google_json/requests/copy_object.rb
@@ -15,7 +15,9 @@ module Fog
                         target_bucket, target_object, options = {})
           request_options = ::Google::Apis::RequestOptions.default.merge(options)
 
-          object = ::Google::Apis::StorageV1::Object.new(**options)
+          # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+          # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+          object = ::Google::Apis::StorageV1::Object.new(**options.transform_keys(&:to_sym))
 
           @storage_json.copy_object(source_bucket, source_object,
                                     target_bucket, target_object,

--- a/lib/fog/storage/google_json/requests/get_object.rb
+++ b/lib/fog/storage/google_json/requests/get_object.rb
@@ -34,7 +34,9 @@ module Fog
                        if_metageneration_match: nil,
                        if_metageneration_not_match: nil,
                        projection: nil,
-                       **options, &_block)
+                       # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+                       # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+                       **options.transform_keys(&:to_sym), &_block)
           raise ArgumentError.new("bucket_name is required") unless bucket_name
           raise ArgumentError.new("object_name is required") unless object_name
 

--- a/lib/fog/storage/google_json/requests/get_object_url.rb
+++ b/lib/fog/storage/google_json/requests/get_object_url.rb
@@ -6,14 +6,18 @@ module Fog
         # Deprecated, redirects to get_object_https_url.rb
         def get_object_url(bucket_name, object_name, expires, options = {})
           Fog::Logger.deprecation("Fog::Storage::Google => #get_object_url is deprecated, use #get_object_https_url instead[/] [light_black](#{caller(0..0)})")
-          get_object_https_url(bucket_name, object_name, expires, **options)
+          # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+          # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+          get_object_https_url(bucket_name, object_name, expires, **options.transform_keys(&:to_sym))
         end
       end
 
       class Mock # :nodoc:all
         def get_object_url(bucket_name, object_name, expires, options = {})
           Fog::Logger.deprecation("Fog::Storage::Google => #get_object_url is deprecated, use #get_object_https_url instead[/] [light_black](#{caller(0..0)})")
-          get_object_https_url(bucket_name, object_name, expires, **options)
+          # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+          # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+          get_object_https_url(bucket_name, object_name, expires, **options.transform_keys(&:to_sym))
         end
       end
     end

--- a/lib/fog/storage/google_json/requests/list_objects.rb
+++ b/lib/fog/storage/google_json/requests/list_objects.rb
@@ -31,7 +31,9 @@ module Fog
 
           @storage_json.list_objects(
             bucket,
-            **options.select { |k, _| allowed_opts.include? k }
+            # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+            # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+            **options.transform_keys(&:to_sym).select { |k, _| allowed_opts.include? k }
           )
         end
       end

--- a/lib/fog/storage/google_json/requests/put_bucket.rb
+++ b/lib/fog/storage/google_json/requests/put_bucket.rb
@@ -17,9 +17,11 @@ module Fog
         def put_bucket(bucket_name,
                        predefined_acl: nil,
                        predefined_default_object_acl: nil,
-                       **options)
+                       # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+                       # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+                       **options.transform_keys(&:to_sym))
           bucket = ::Google::Apis::StorageV1::Bucket.new(
-            **options.merge(:name => bucket_name)
+            **options.transform_keys(&:to_sym).merge(:name => bucket_name)
           )
 
           @storage_json.insert_bucket(

--- a/lib/fog/storage/google_json/requests/put_object.rb
+++ b/lib/fog/storage/google_json/requests/put_object.rb
@@ -47,11 +47,13 @@ module Fog
                        if_metageneration_not_match: nil,
                        kms_key_name: nil,
                        predefined_acl: nil,
-                       **options)
+                       # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+                       # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+                       **options.transform_keys(&:to_sym))
           data, options = normalize_data(data, options)
 
           object_config = ::Google::Apis::StorageV1::Object.new(
-            **options.merge(:name => object_name)
+            **options.transform_keys(&:to_sym).merge(:name => object_name)
           )
 
           @storage_json.insert_object(

--- a/lib/fog/storage/google_xml/models/file.rb
+++ b/lib/fog/storage/google_xml/models/file.rb
@@ -109,7 +109,9 @@ module Fog
           options["Expires"] = expires if expires
           options.merge!(metadata)
 
-          data = service.put_object(directory.key, key, body, **options)
+          # **options.transform_keys(&:to_sym) is needed so paperclip doesn't break on Ruby 2.6
+          # TODO(temikus): remove this once Ruby 2.6 is deprecated for good
+          data = service.put_object(directory.key, key, body, **options.transform_keys(&:to_sym))
           merge_attributes(data.headers.reject { |key, _value| ["Content-Length", "Content-Type"].include?(key) })
           self.content_length = Fog::Storage.get_body_size(body)
           self.content_type ||= Fog::Storage.get_content_type(body)


### PR DESCRIPTION
Fixes #535
