### PR TITLE
Avoid duplicate GET requests when retrieving body

### DIFF
--- a/lib/fog/storage/google_json/models/file.rb
+++ b/lib/fog/storage/google_json/models/file.rb
@@ -45,7 +45,16 @@ module Fog
         end
 
         def body
-          last_modified && (file = collection.get(identity)) ? attributes[:body] ||= file.body : attributes[:body] ||= ""
+          return attributes[:body] if attributes.key?(:body)
+
+          file = collection.get(identity)
+
+          attributes[:body] =
+            if file
+              file.attributes[:body]
+            else
+              ""
+            end
         end
 
         def body=(new_body)


### PR DESCRIPTION
Previously the response body would be loaded twice in memory whenever
`GoogleJSON::File#body` was called. This was happening because inside
the ternary condition, `file.body` was recursively calling itself twice
even though the body was already loaded. We rewrite this method to be
simpler and to have a proper base condition.

Closes https://github.com/fog/fog-google/issues/541