### PR TITLE
Disable transfer timeout by default in storage request

### DIFF
--- a/lib/fog/storage/google_json/real.rb
+++ b/lib/fog/storage/google_json/real.rb
@@ -26,7 +26,7 @@ module Fog
 
           @storage_json.client_options.open_timeout_sec = options[:open_timeout_sec] if options[:open_timeout_sec]
           @storage_json.client_options.read_timeout_sec = options[:read_timeout_sec] if options[:read_timeout_sec]
-          @storage_json.client_options.send_timeout_sec = options[:send_timeout_sec] if options[:send_timeout_sec]
+          @storage_json.client_options.send_timeout_sec = options[:send_timeout_sec] || 0
         end
 
         def signature(params)


### PR DESCRIPTION
By default, httpclient will prevent any request from going longer than 120 seconds, which will cause any transfer to take longer than that to abort. As a result, the Google client will raise `Google::Apis::TransmissionError: execution expired` for any transfer that is longer than 2 minutes.

`Google::Apis::RequestOptions.default.retries` can be used to resume aborted uploads, but the default is set to 0. Plus, `max_elapsed_time` is set to 15 minutes by default, so this value would need to be raised as well. Support for this was added in https://github.com/googleapis/google-api-ruby-client/pull/8106, but this is a recent feature.

The main way we can fix this issue is to raise the timeout to a large value to disable it outright. Since httpclient uses
`Timeout::timeout`, which can be dangerous, we disable this timeout by default if no `send_timeout_sec` is specified.

Closes https://github.com/fog/fog-google/issues/323