### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -39,7 +39,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -66,7 +66,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -93,7 +93,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -120,7 +120,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -147,7 +147,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -174,7 +174,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 
@@ -201,7 +201,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0' ]
+        ruby-version: [ '2.7', '3.0', '3.1' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', 'head', 'truffleruby-head']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head', 'truffleruby-head']
 
     steps:
       - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix for all spec runs.

The unit tests ran green on my fork, but the integration tests didn't run at all.  So there may be failures in the integration specs that need to be resolved.