### PR TITLE
Allow bumping fog-core

### DIFF
--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |spec|
   # As of 0.1.1
   spec.required_ruby_version = ">= 2.0"
 
-  # Locked until https://github.com/fog/fog-google/issues/417 is resolved
-  spec.add_dependency "fog-core", "<= 2.1.0"
+  spec.add_dependency "fog-core", "< 2.3"
   spec.add_dependency "fog-json", "~> 1.2"
   spec.add_dependency "fog-xml", "~> 0.1.0"
 


### PR DESCRIPTION
This is an alternative to https://github.com/fog/fog-google/pull/422, in order to get newer versions of fog-core to enable compatibility with other fog provider gems.  

Looking into the history, it looks like a similar change was reverted: https://github.com/fog/fog-google/pull/419 https://github.com/fog/fog-google/pull/487

There is talk of a regression, but all unit tests pass and as far as I can tell the only issue is the deprecation warnings.

It's been years since talk doing the update 'properly' and https://github.com/fog/fog-google/pull/422 seems to be stuck in limbo.  At this point this gem lagging behind fog-core and other provider gems is no longer a minor inconvenience--it is blocking us from getting new features in other provider gems and from upgrading to Ruby 3.  

We would much rather allow the deprecation warnings than continue to be stuck on a very old version (1.7, per [this comment](https://github.com/fog/fog-google/pull/422#issuecomment-423393039)).  That version is blocking us on upgrading other gems because some of its dependencies are locked to old versions that are incompatible with other gems.

After this is merged, we can tackled the deprecation warnings piecemeal, or we those who are annoyed by them can silence them (or pin to fog-core 2.1).

cc @Temikus @geemus 

Authored-by: Seth Boyles <sboyles@pivotal.io>