### PR TITLE
Attempt to make integration tests lighter

### DIFF
--- a/.github/workflows/integration-sql.yml
+++ b/.github/workflows/integration-sql.yml
@@ -1,0 +1,44 @@
+# SQL tests are carried own in its' own job as they're extremely heavy so there
+# is no need to run them if SQL code or deps haven't changed and you cannot
+# trigger jobs based on file changes in the same workflow.
+# See: https://github.com/actions/runner/issues/456
+name: integration-tests-sql
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    types: [ assigned, opened, synchronize, reopened, labeled ]
+    # Only run SQL integration tests if SQL code or deps have changed
+    paths:
+      - 'lib/fog/google/sql/**'
+      - 'fog-google.gemspec'
+
+jobs:
+  test-sql:
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        ruby-version: [ '2.7', '3.0', '3.1' ]
+      # Integration tests from the same task cannot run in parallel yet due to cleanup
+      max-parallel: 1
+
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        env:
+          # Needs to be set up for self-hosted runners, see:
+          # https://github.com/ruby/setup-ruby#using-self-hosted-runners
+          # Image used in runners: summerwind/actions-runner
+          ImageOS: ubuntu20
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: >-
+          ./.github/scripts/setup_creds.sh &&
+          bundle exec rake test:sql

--- a/.github/workflows/integration-sql.yml
+++ b/.github/workflows/integration-sql.yml
@@ -13,6 +13,7 @@ on:
     # Only run SQL integration tests if SQL code or deps have changed
     paths:
       - 'lib/fog/google/sql/**'
+      - 'test/integration/sql/**'
       - 'fog-google.gemspec'
 
 jobs:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -196,30 +196,3 @@ jobs:
         run: >-
           ./.github/scripts/setup_creds.sh &&
           bundle exec rake test:pubsub
-
-  test-sql:
-    runs-on: self-hosted
-    strategy:
-      matrix:
-        ruby-version: [ '2.7', '3.0', '3.1' ]
-      # Integration tests from the same task cannot run in parallel yet due to cleanup
-      max-parallel: 1
-
-    steps:
-      - uses: actions/checkout@v3.1.0
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        env:
-          # Needs to be set up for self-hosted runners, see:
-          # https://github.com/ruby/setup-ruby#using-self-hosted-runners
-          # Image used in runners: summerwind/actions-runner
-          ImageOS: ubuntu20
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies
-        run: bundle install
-      - name: Run tests
-        run: >-
-          ./.github/scripts/setup_creds.sh &&
-          bundle exec rake test:sql


### PR DESCRIPTION
Starting with separating SQL integration tests into their own job as that allows us to only trigger it on PR's where the code or deps have actually changed.