### PR TITLE
improve perf for default_signer: Don't create new PKey::RSA if we already can sign

### DIFF
--- a/lib/fog/storage/google_json/real.rb
+++ b/lib/fog/storage/google_json/real.rb
@@ -135,7 +135,8 @@ DATA
         #   See https://cloud.google.com/storage/docs/access-control/signed-urls-v2
         # @return [String] Signature binary blob
         def default_signer(string_to_sign)
-          key = OpenSSL::PKey::RSA.new(@storage_json.authorization.signing_key)
+          key = @storage_json.authorization.signing_key
+          key = OpenSSL::PKey::RSA.new(@storage_json.authorization.signing_key) unless key.respond_to?(:sign)
           digest = OpenSSL::Digest::SHA256.new
           return key.sign(digest, string_to_sign)
         end


### PR DESCRIPTION
As of today we creating new `OpenSSL::PKey::RSA` when we sign, even if the existing `signing_key` is already a `OpenSSL::PKey::RSA`.

In google ruby gem they are doing the same approach - https://github.com/googleapis/google-cloud-ruby/blob/main/google-cloud-storage/lib/google/cloud/storage/file/signer_v2.rb#L137

```
Warming up --------------------------------------
                sign   119.000  i/100ms
                 new   179.000  i/100ms
Calculating -------------------------------------
                sign      1.199k (± 0.7%) i/s -      6.069k in   5.063095s
                 new      1.791k (± 0.6%) i/s -      9.129k in   5.096376s

Comparison:
                 new:     1791.3 i/s
                sign:     1198.7 i/s - 1.49x  slower
```

source: https://gist.github.com/yosiat/372bc468d23c568cd8722af7f56a2b03