### PR TITLE
Remove unnecessary workflow stage

### DIFF
--- a/.github/workflows/integration-compute-core.yml
+++ b/.github/workflows/integration-compute-core.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: >-
           ./.github/scripts/setup_creds.sh &&

--- a/.github/workflows/integration-compute-instance_groups.yml
+++ b/.github/workflows/integration-compute-instance_groups.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: >-
           ./.github/scripts/setup_creds.sh &&

--- a/.github/workflows/integration-compute-loadbalancing.yml
+++ b/.github/workflows/integration-compute-loadbalancing.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: >-
           ./.github/scripts/setup_creds.sh &&

--- a/.github/workflows/integration-compute-networking.yml
+++ b/.github/workflows/integration-compute-networking.yml
@@ -39,8 +39,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: >-
           ./.github/scripts/setup_creds.sh &&

--- a/.github/workflows/integration-monitoring.yml
+++ b/.github/workflows/integration-monitoring.yml
@@ -40,8 +40,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: >-
           ./.github/scripts/setup_creds.sh &&

--- a/.github/workflows/integration-pubsub.yml
+++ b/.github/workflows/integration-pubsub.yml
@@ -40,8 +40,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: >-
           ./.github/scripts/setup_creds.sh &&

--- a/.github/workflows/integration-sql.yml
+++ b/.github/workflows/integration-sql.yml
@@ -40,8 +40,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: >-
           ./.github/scripts/setup_creds.sh &&

--- a/.github/workflows/integration-storage.yml
+++ b/.github/workflows/integration-storage.yml
@@ -41,8 +41,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - name: Install dependencies
-        run: bundle install
       - name: Run tests
         run: >-
           ./.github/scripts/setup_creds.sh &&


### PR DESCRIPTION
`bundler` is already set up as a part of `setup-ruby` workflow when caching gems so it's no longer necessary to call it separately.