### PR TITLE
Remove deprecated ruby versions from unit tests

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head', 'truffleruby-head']
+        ruby-version: ['2.7', '3.0', '3.1', 'head', 'truffleruby-head']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
To fix the recently failing `unit` workflows.