### PR TITLE
Use `Minitest::Test` instead of `MiniTest::Test`

### DIFF
--- a/test/helpers/integration_test_helper.rb
+++ b/test/helpers/integration_test_helper.rb
@@ -93,7 +93,7 @@ KEY
 RETRIABLE_TRIES = 3
 RETRIABLE_BASE_INTERVAL = 50
 
-class FogIntegrationTest < MiniTest::Test
+class FogIntegrationTest < Minitest::Test
   def namespaced_name
     "#{self.class}_#{name}"
   end

--- a/test/unit/compute/test_common_collections.rb
+++ b/test/unit/compute/test_common_collections.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestCollections < MiniTest::Test
+class UnitTestCollections < Minitest::Test
   def setup
     Fog.mock!
 

--- a/test/unit/compute/test_common_models.rb
+++ b/test/unit/compute/test_common_models.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestModels < MiniTest::Test
+class UnitTestModels < Minitest::Test
   def setup
     Fog.mock!
     @client = Fog::Compute.new(provider: "google",

--- a/test/unit/compute/test_server.rb
+++ b/test/unit/compute/test_server.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestServer < MiniTest::Test
+class UnitTestServer < Minitest::Test
   def setup
     Fog.mock!
     @client = Fog::Compute.new(provider: "google",

--- a/test/unit/dns/test_common_collections.rb
+++ b/test/unit/dns/test_common_collections.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestDNSCollections < MiniTest::Test
+class UnitTestDNSCollections < Minitest::Test
   def setup
     Fog.mock!
     @client = Fog::DNS.new(provider: "google",

--- a/test/unit/monitoring/test_comon_collections.rb
+++ b/test/unit/monitoring/test_comon_collections.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestMonitoringCollections < MiniTest::Test
+class UnitTestMonitoringCollections < Minitest::Test
   def setup
     Fog.mock!
     @client = Fog::Monitoring.new(provider: "google",

--- a/test/unit/pubsub/test_common_collections.rb
+++ b/test/unit/pubsub/test_common_collections.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestPubsubCollections < MiniTest::Test
+class UnitTestPubsubCollections < Minitest::Test
   def setup
     Fog.mock!
     @client = Fog::Google::Pubsub.new(google_project: "foo")

--- a/test/unit/sql/test_common_collections.rb
+++ b/test/unit/sql/test_common_collections.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestSQLCollections < MiniTest::Test
+class UnitTestSQLCollections < Minitest::Test
   def setup
     Fog.mock!
     @client = Fog::Google::SQL.new(google_project: "foo")

--- a/test/unit/storage/test_common_json_collections.rb
+++ b/test/unit/storage/test_common_json_collections.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestStorageJSONCollections < MiniTest::Test
+class UnitTestStorageJSONCollections < Minitest::Test
   def setup
     Fog.mock!
     @client = Fog::Storage.new(provider: "google",

--- a/test/unit/storage/test_common_xml_collections.rb
+++ b/test/unit/storage/test_common_xml_collections.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestStorageXMLCollections < MiniTest::Test
+class UnitTestStorageXMLCollections < Minitest::Test
   def setup
     Fog.mock!
     @client = Fog::Storage.new(provider: "google",

--- a/test/unit/storage/test_json_requests.rb
+++ b/test/unit/storage/test_json_requests.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestJsonRequests < MiniTest::Test
+class UnitTestJsonRequests < Minitest::Test
   def setup
     Fog.mock!
     @client = Fog::Storage.new(provider: "google",

--- a/test/unit/storage/test_xml_requests.rb
+++ b/test/unit/storage/test_xml_requests.rb
@@ -1,6 +1,6 @@
 require "helpers/test_helper"
 
-class UnitTestXMLRequests < MiniTest::Test
+class UnitTestXMLRequests < Minitest::Test
   def setup
     Fog.mock!
     @client = Fog::Storage.new(provider: "google",


### PR DESCRIPTION
### Overview

In this pull request, we fixed the CI build.

```sh
uninitialized constant MiniTest (NameError)
Did you mean?  Minitest
```