### PR TITLE
Spruce up attaching and detaching disks on running servers

### DIFF
--- a/examples/create_instance_and_attach_disk_later.rb
+++ b/examples/create_instance_and_attach_disk_later.rb
@@ -1,0 +1,86 @@
+# All examples presume that you have a ~/.fog credentials file set up.
+# More info on it can be found here: http://fog.io/about/getting_started.html
+
+require "bundler"
+Bundler.require(:default, :development)
+
+ZONE = "us-central1-f"
+PROJECT = Fog.credentials[:google_project]
+
+def example
+  p "Connecting to Google API"
+  connection = Fog::Compute.new(:provider => "Google")
+
+  p "Creating disk"
+  disk = connection.disks.create(
+    :name => "fog-smoke-test-#{Time.now.to_i}",
+    :size_gb => 10,
+    :zone => ZONE,
+    :source_image => "debian-11-bullseye-v20220920"
+  )
+
+  p "Creating a second disk"
+  attached_disk = connection.disks.create(
+    :name => "fog-smoke-test-#{Time.now.to_i}",
+    :size_gb => 10,
+    :zone => ZONE
+  )
+
+  p "Waiting for disks to be ready"
+  disk.wait_for { ready? }
+  attached_disk.wait_for { ready? }
+
+  p "Creating a server"
+  server = connection.servers.create(
+    :name => "fog-smoke-test-#{Time.now.to_i}",
+    :disks => [disk.attached_disk_obj(boot: true, auto_delete: true)],
+    :machine_type => "n1-standard-1",
+    :private_key_path => File.expand_path("~/.ssh/id_rsa"),
+    :public_key_path => File.expand_path("~/.ssh/id_rsa.pub"),
+    :zone => ZONE,
+    # Will be simplified, see https://github.com/fog/fog-google/issues/360
+    :network_interfaces => [{ :network => "global/networks/default",
+                              :access_configs => [{
+                                :name => "External NAT",
+                                :type => "ONE_TO_ONE_NAT"
+                              }] }],
+    :username => ENV["USER"]
+  )
+
+  p "Attach second disk to the running server"
+  device_name = "fog-smoke-test-device-#{Time.now.to_i}"
+  # See https://github.com/fog/fog-google/blob/master/lib/fog/compute/google/models/disk.rb#L75-L107
+  # See https://github.com/fog/fog-google/blob/master/lib/fog/compute/google/models/server.rb#L35-L50
+  config_hash = {
+    :device_name => device_name,
+    :source => "https://www.googleapis.com/compute/v1/projects/#{PROJECT}/zones/#{ZONE}/disks/#{attached_disk.name}"
+  }
+  raise "Could not attach second disk" unless connection.attach_disk(server.name, ZONE, config_hash)
+
+  p "Waiting for disk to be attached"
+  attached_disk.wait_for { ! users.nil? && users != []}
+
+  p "Detach second disk"
+  raise "Could not detach second disk" unless connection.detach_disk(server.name, ZONE, device_name)
+
+  p "Waiting for second disk to be detached"
+  attached_disk.wait_for { users.nil? || users == []}
+
+  p "Deleting server"
+  raise "Could not delete server." unless server.destroy
+
+  p "Destroying second disk"
+  raise "Could not delete second disk." unless attached_disk.destroy
+
+  p "Waiting for second disk to be destroyed"
+  begin
+    rc = attached_disk.wait_for { status.nil? || status == 'DELETING' }
+
+  rescue => e
+    if e.message !~ /not found/ && e.message !~ /notFound/
+      raise e
+    end
+  end
+end
+
+example

--- a/lib/fog/compute/google/models/disks.rb
+++ b/lib/fog/compute/google/models/disks.rb
@@ -36,6 +36,10 @@ module Fog
         def get(identity, zone = nil)
           if zone
             disk = service.get_disk(identity, zone).to_h
+
+            # Force the hash to contain a :users key so that it will override any :users key in the existing object
+            disk[:users] = nil unless disk.include?(:users)
+
             return new(disk)
           elsif identity
             response = all(:filter => "name eq #{identity}",

--- a/lib/fog/compute/google/models/disks.rb
+++ b/lib/fog/compute/google/models/disks.rb
@@ -35,6 +35,7 @@ module Fog
 
         def get(identity, zone = nil)
           if zone
+
             disk = service.get_disk(identity, zone).to_h
 
             # Force the hash to contain a :users key so that it will override any :users key in the existing object
@@ -49,7 +50,8 @@ module Fog
           end
         rescue ::Google::Apis::ClientError => e
           raise e unless e.status_code == 404
-          nil
+          # Return an empty object so that wait_for processes the block
+          return new({:status => nil})
         end
 
         # Returns an attached disk configuration hash.

--- a/lib/fog/compute/google/models/disks.rb
+++ b/lib/fog/compute/google/models/disks.rb
@@ -35,7 +35,6 @@ module Fog
 
         def get(identity, zone = nil)
           if zone
-
             disk = service.get_disk(identity, zone).to_h
 
             # Force the hash to contain a :users key so that it will override any :users key in the existing object

--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -279,7 +279,7 @@ module Fog
           if disk.is_a? Disk
             disk_obj = disk.get_attached_disk
           elsif disk.is_a? String
-            disk_obj = service.disks.attached_disk_obj(disk, attached_disk_options)
+            disk_obj = service.disks.attached_disk_obj(disk, **attached_disk_options)
           end
 
           data = service.attach_disk(identity, zone_name, disk_obj)

--- a/test/unit/compute/test_disk.rb
+++ b/test/unit/compute/test_disk.rb
@@ -1,0 +1,26 @@
+require "helpers/test_helper"
+
+class UnitTestDisk < Minitest::Test
+  def setup
+    Fog.mock!
+    @client = Fog::Compute.new(provider: "google",
+                               google_project: "foo")
+  end
+
+  def teardown
+    Fog.unmock!
+  end
+
+  def test_new_disk
+    disk = Fog::Compute::Google::Disk.new(
+      :name         => "fog-1",
+      :size_gb      => 10,
+      :zone         => "us-central1-a",
+      :source_image => "debian-7-wheezy-v20131120"
+    )
+    assert_equal("fog-1",                     disk.name,         "Fog::Compute::Google::Disk name is incorrect: #{disk.name}")
+    assert_equal(10,                          disk.size_gb,      "Fog::Compute::Google::Disk size_gb is incorrect: #{disk.size_gb}")
+    assert_equal("us-central1-a",             disk.zone,         "Fog::Compute::Google::Disk zone is incorrect: #{disk.zone}")
+    assert_equal("debian-7-wheezy-v20131120", disk.source_image, "Fog::Compute::Google::Disk source_image is incorrect: #{disk.source_image}")
+  end
+end


### PR DESCRIPTION
As a new fog-google user, I encountered various issues in dynamically attaching and detaching disks against a running server, namely:
* https://github.com/fog/fog-google/issues/611
* https://github.com/fog/fog-google/issues/612
* Error when running under Ruby 3.x: `ArgumentError: wrong number of arguments (given 2, expected 1)`
* No example that demonstrates usage how to attach and detach disks against a running server