### PR TITLE
Deprecate Ruby-2.0 support

### DIFF
--- a/.github/workflows/integration-compute-core.yml
+++ b/.github/workflows/integration-compute-core.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0', '3.1' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 

--- a/.github/workflows/integration-compute-instance_groups.yml
+++ b/.github/workflows/integration-compute-instance_groups.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0', '3.1' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 

--- a/.github/workflows/integration-compute-loadbalancing.yml
+++ b/.github/workflows/integration-compute-loadbalancing.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0', '3.1' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 

--- a/.github/workflows/integration-compute-networking.yml
+++ b/.github/workflows/integration-compute-networking.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0', '3.1' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 

--- a/.github/workflows/integration-monitoring.yml
+++ b/.github/workflows/integration-monitoring.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0', '3.1' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 

--- a/.github/workflows/integration-pubsub.yml
+++ b/.github/workflows/integration-pubsub.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0', '3.1' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 

--- a/.github/workflows/integration-sql.yml
+++ b/.github/workflows/integration-sql.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0', '3.1' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 

--- a/.github/workflows/integration-storage.yml
+++ b/.github/workflows/integration-storage.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ruby-version: [ '2.7', '3.0', '3.1' ]
+        ruby-version: [ '3.0', '3.1', '3.2' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
       max-parallel: 1
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', 'head', 'truffleruby-head']
+        ruby-version: [ '3.0', '3.1', '3.2', 'head', 'truffleruby-head']
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ $ bundle exec pry
 
 ## Supported Ruby Versions
 
-Fog-google is currently supported on Ruby 2.7+.
+Fog-google is currently supported on Ruby 3.0+.
 
 In general we support (and run our CI) for Ruby versions that are actively supported
 by Ruby Core - that is, Ruby versions that are not end of life. Older versions of


### PR DESCRIPTION
Ruby 2 has been long EOL so deprecating it as per our support policy: https://github.com/fog/fog-google#supported-ruby-versions