### PR TITLE
Add support for discard_local_ssd when stopping an instance

### DIFF
--- a/lib/fog/compute/google/models/server.rb
+++ b/lib/fog/compute/google/models/server.rb
@@ -339,10 +339,10 @@ module Fog
           operation
         end
 
-        def stop(async = true)
+        def stop(async = true, discard_local_ssd=false)
           requires :identity, :zone
 
-          data = service.stop_server(identity, zone_name)
+          data = service.stop_server(identity, zone_name, discard_local_ssd)
           operation = Fog::Compute::Google::Operations
                       .new(:service => service)
                       .get(data.name, data.zone)

--- a/lib/fog/compute/google/requests/stop_server.rb
+++ b/lib/fog/compute/google/requests/stop_server.rb
@@ -10,8 +10,8 @@ module Fog
       end
 
       class Real
-        def stop_server(identity, zone)
-          @compute.stop_instance(@project, zone.split("/")[-1], identity)
+        def stop_server(identity, zone, discard_local_ssd=false)
+          @compute.stop_instance(@project, zone.split("/")[-1], identity, discard_local_ssd: discard_local_ssd)
         end
       end
     end

--- a/test/integration/compute/core_compute/test_servers.rb
+++ b/test/integration/compute/core_compute/test_servers.rb
@@ -132,6 +132,18 @@ class TestServers < FogIntegrationTest
     assert server.ready?
   end
 
+  def test_start_stop_discard_local_ssd
+    server = @factory.create
+
+    async = true
+    discard_local_ssd = true
+
+    server.stop(async, discard_local_ssd)
+    server.wait_for { stopped? }
+
+    assert server.stopped?
+  end
+
   def test_attach_disk
     # Creating server
     server = @factory.create


### PR DESCRIPTION
Stopping an instance with local SSD throws this error:
```
badRequest: VM has a Local SSD attached but an undefined value for `discard-local-ssd`. If using gcloud, please add `--discard-local-ssd=false` or `--discard-local-ssd=true` to your command.
```

The Google API `Google::Apis::Compute::stop_instance` (in [service.rb](https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-compute_v1/lib/google/apis/compute_v1/service.rb)) supports a keyword argument `discard_local_ssd`, but fog-google does not. This PR adds an optional argument to allow assigning a value when stopping an instance. The default is false, both to mimic Google default, and to preserve backward compatibility with existing fog-google users.

To stop an instance containing local SSD:
```
async = true
discard_local_ssd = true
resp = instance.stop(async, discard_local_ssd)
```

References:
* [Stop a VM with Local SSD](https://cloud.google.com/compute/docs/disks/local-ssd#stop_instance)
* [instances.stop](https://cloud.google.com/compute/docs/reference/rest/v1/instances/stop)