### PR TITLE
Migrate the Integration tests to new ARC runners

### DIFF
--- a/.github/workflows/integration-compute-core.yml
+++ b/.github/workflows/integration-compute-core.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   test-compute:
-    runs-on: self-hosted
+    runs-on: fog-arc-runner
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-compute-instance_groups.yml
+++ b/.github/workflows/integration-compute-instance_groups.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: fog-arc-runner
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-compute-loadbalancing.yml
+++ b/.github/workflows/integration-compute-loadbalancing.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: fog-arc-runner
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-compute-networking.yml
+++ b/.github/workflows/integration-compute-networking.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: fog-arc-runner
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-monitoring.yml
+++ b/.github/workflows/integration-monitoring.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: fog-arc-runner
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-pubsub.yml
+++ b/.github/workflows/integration-pubsub.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: fog-arc-runner
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-sql.yml
+++ b/.github/workflows/integration-sql.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: fog-arc-runner
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-storage.yml
+++ b/.github/workflows/integration-storage.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   test:
-    runs-on: self-hosted
+    runs-on: fog-arc-runner
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]


### PR DESCRIPTION
The old `self-hosted` setup has proven to be very flaky. Transitioning to the new ARC setup, see: https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller