### PR TITLE
Add concurrency groups

### DIFF
--- a/.github/workflows/integration-compute-core.yml
+++ b/.github/workflows/integration-compute-core.yml
@@ -23,6 +23,12 @@ on:
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
 
+# Setting hard concurrency limit for the project due to cleanup
+# TODO(fog-google#626): remove this once cleanup is fixed
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   test-compute:
     runs-on: fog-arc-runner
@@ -30,6 +36,7 @@ jobs:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]
       # Integration tests from the same task cannot run in parallel yet due to cleanup
+      # TODO(fog-google#626): remove this once cleanup is fixed
       max-parallel: 1
 
     steps:

--- a/.github/workflows/integration-compute-core.yml
+++ b/.github/workflows/integration-compute-core.yml
@@ -22,6 +22,8 @@ on:
       - 'lib/fog/google.rb'
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
+      # Trigger when workflow itself is updated
+      - '.github/workflows/integration-compute-core.yml'
 
 # Setting hard concurrency limit for the project due to cleanup
 # TODO(fog-google#626): remove this once cleanup is fixed

--- a/.github/workflows/integration-compute-instance_groups.yml
+++ b/.github/workflows/integration-compute-instance_groups.yml
@@ -22,6 +22,8 @@ on:
       - 'lib/fog/google.rb'
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
+      # Trigger when workflow itself is updated
+      - '.github/workflows/integration-compute-instance_groups.yml'
 
 # Setting hard concurrency limit for the project due to cleanup
 # TODO(fog-google#626): remove this once cleanup is fixed

--- a/.github/workflows/integration-compute-instance_groups.yml
+++ b/.github/workflows/integration-compute-instance_groups.yml
@@ -23,6 +23,13 @@ on:
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
 
+# Setting hard concurrency limit for the project due to cleanup
+# TODO(fog-google#626): remove this once cleanup is fixed
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+
 jobs:
   test:
     runs-on: fog-arc-runner

--- a/.github/workflows/integration-compute-loadbalancing.yml
+++ b/.github/workflows/integration-compute-loadbalancing.yml
@@ -23,6 +23,13 @@ on:
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
 
+# Setting hard concurrency limit for the project due to cleanup
+# TODO(fog-google#626): remove this once cleanup is fixed
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+
 jobs:
   test:
     runs-on: fog-arc-runner

--- a/.github/workflows/integration-compute-loadbalancing.yml
+++ b/.github/workflows/integration-compute-loadbalancing.yml
@@ -22,6 +22,8 @@ on:
       - 'lib/fog/google.rb'
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
+      # Trigger when workflow itself is updated
+      - '.github/workflows/integration-compute-loadbalancing.yml'
 
 # Setting hard concurrency limit for the project due to cleanup
 # TODO(fog-google#626): remove this once cleanup is fixed

--- a/.github/workflows/integration-compute-networking.yml
+++ b/.github/workflows/integration-compute-networking.yml
@@ -23,6 +23,12 @@ on:
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
 
+# Setting hard concurrency limit for the project due to cleanup
+# TODO(fog-google#626): remove this once cleanup is fixed
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: fog-arc-runner

--- a/.github/workflows/integration-compute-networking.yml
+++ b/.github/workflows/integration-compute-networking.yml
@@ -22,6 +22,8 @@ on:
       - 'lib/fog/google.rb'
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
+      # Trigger when workflow itself is updated
+      - '.github/workflows/integration-compute-networking.yml'
 
 # Setting hard concurrency limit for the project due to cleanup
 # TODO(fog-google#626): remove this once cleanup is fixed

--- a/.github/workflows/integration-monitoring.yml
+++ b/.github/workflows/integration-monitoring.yml
@@ -24,6 +24,12 @@ on:
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
 
+# Setting hard concurrency limit for the project due to cleanup
+# TODO(fog-google#626): remove this once cleanup is fixed
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: fog-arc-runner

--- a/.github/workflows/integration-monitoring.yml
+++ b/.github/workflows/integration-monitoring.yml
@@ -23,6 +23,8 @@ on:
       - 'lib/fog/google.rb'
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
+      # Trigger when workflow itself is updated
+      - '.github/workflows/integration-monitoring.yml'
 
 # Setting hard concurrency limit for the project due to cleanup
 # TODO(fog-google#626): remove this once cleanup is fixed

--- a/.github/workflows/integration-pubsub.yml
+++ b/.github/workflows/integration-pubsub.yml
@@ -23,6 +23,8 @@ on:
       - 'lib/fog/google.rb'
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
+      # Trigger when workflow itself is updated
+      - '.github/workflows/integration-pubsub.yml'
 
 # Setting hard concurrency limit for the project due to cleanup
 # TODO(fog-google#626): remove this once cleanup is fixed

--- a/.github/workflows/integration-pubsub.yml
+++ b/.github/workflows/integration-pubsub.yml
@@ -24,6 +24,12 @@ on:
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
 
+# Setting hard concurrency limit for the project due to cleanup
+# TODO(fog-google#626): remove this once cleanup is fixed
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: fog-arc-runner

--- a/.github/workflows/integration-sql.yml
+++ b/.github/workflows/integration-sql.yml
@@ -23,6 +23,8 @@ on:
       - 'lib/fog/google.rb'
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
+      # Trigger when workflow itself is updated
+      - '.github/workflows/integration-sql.yml'
 
 # Setting hard concurrency limit for the project due to cleanup
 # TODO(fog-google#626): remove this once cleanup is fixed

--- a/.github/workflows/integration-sql.yml
+++ b/.github/workflows/integration-sql.yml
@@ -24,6 +24,12 @@ on:
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
 
+# Setting hard concurrency limit for the project due to cleanup
+# TODO(fog-google#626): remove this once cleanup is fixed
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: fog-arc-runner

--- a/.github/workflows/integration-storage.yml
+++ b/.github/workflows/integration-storage.yml
@@ -24,6 +24,8 @@ on:
       - 'lib/fog/google.rb'
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
+      # Trigger when workflow itself is updated
+      - '.github/workflows/integration-storage.yml'
 
 # Setting hard concurrency limit for the project due to cleanup
 # TODO(fog-google#626): remove this once cleanup is fixed

--- a/.github/workflows/integration-storage.yml
+++ b/.github/workflows/integration-storage.yml
@@ -25,6 +25,12 @@ on:
       # Trigger workflow on version upgrade
       - 'lib/fog/google/version.rb'
 
+# Setting hard concurrency limit for the project due to cleanup
+# TODO(fog-google#626): remove this once cleanup is fixed
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   test:
     runs-on: fog-arc-runner

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ master ]
 
+# Cancel in-progress jobs of the same ref or run_id
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-unit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add concurrency groups to integration tests to stop cleanup routines from stepping over each other.
- Add concurrency group to unit tests to cancel the runs if we updated the PR ref
- Trigger workflows when they get updated so we can test workflow changes inside the PRs