### PR TITLE
storage: fix incorrect API scopes for IAM SignBlob API

### DIFF
--- a/lib/fog/google/shared.rb
+++ b/lib/fog/google/shared.rb
@@ -67,20 +67,21 @@ module Fog
           ::Google::Apis.logger.level = ::Logger::DEBUG
         end
 
-        auth = nil
-
-        if options[:google_json_key_location] || options[:google_json_key_string]
-          auth = process_key_auth(options)
-        elsif options[:google_auth]
-          auth = options[:google_auth]
-        elsif options[:google_application_default]
-          auth = process_application_default_auth(options)
-        else
-          auth = process_fallback_auth(options)
+        initialize_auth(options).tap do |auth|
+          ::Google::Apis::RequestOptions.default.authorization = auth
         end
+      end
 
-        ::Google::Apis::RequestOptions.default.authorization = auth
-        auth
+      def initialize_auth(options)
+        if options[:google_json_key_location] || options[:google_json_key_string]
+          process_key_auth(options)
+        elsif options[:google_auth]
+          options[:google_auth]
+        elsif options[:google_application_default]
+          process_application_default_auth(options)
+        else
+          process_fallback_auth(options)
+        end
       end
 
       ##

--- a/lib/fog/storage/google_json.rb
+++ b/lib/fog/storage/google_json.rb
@@ -29,7 +29,7 @@ module Fog
 
       # Version of IAM API used for blob signing, see Fog::Storage::GoogleJSON::Real#iam_signer
       GOOGLE_STORAGE_JSON_IAM_API_VERSION = "v1".freeze
-      GOOGLE_STORAGE_JSON_IAM_API_SCOPE_URLS = %w(https://www.googleapis.com/auth/devstorage.full_control).freeze
+      GOOGLE_STORAGE_JSON_IAM_API_SCOPE_URLS = %w(https://www.googleapis.com/auth/iam).freeze
 
       # TODO: Come up with a way to only request a subset of permissions.
       # https://cloud.google.com/storage/docs/json_api/v1/how-tos/authorizing


### PR DESCRIPTION
Previously when a service account attempted to use the IAM SignBlob API, the request would fail with a 403
`ACCESS_TOKEN_SCOPE_INSUFFICIENT` because the wrong scope was requested.

As documented in
https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/signBlob, either `https://www.googleapis.com/auth/iam` or
`https://www.googleapis.com/auth/cloud-platform` is needed.

This commit fixes an issue where the default authorization header with the `https://www.googleapis.com/auth/devstorage.full_control` scope was being used by the IAM service. This occurred because the previous code did not actually set the scope properly, and for the IAM service to work properly, we need to request a new access token with the correct scope.

Note that the service account in question needs to have the `Service Account Token Creator` IAM role to work.

Closes #599