### PR TITLE
Remove test files from package

### DIFF
--- a/fog-google.gemspec
+++ b/fog-google.gemspec
@@ -12,9 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/fog/fog-google"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?("test/") }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   # As of 0.1.1


### PR DESCRIPTION
This pull request updates the `*.gemspec` file to optimize the gem package size and structure. The changes include:

- Modified `files` to exclude test files from the package.
- Removed the deprecated `test_files` specification as it is no longer recommended.

These changes reduce the extracted package size from **2.7MB** to **2.2 MB**.

Benefits:

- Reduced container sizes when the gem is included
- Shorter download times for developers / CI

References:

- https://github.com/rubygems/guides/issues/90
- https://github.com/rubygems/bundler/pull/3207
- [Template for the `*.gemspec` file generated by `bundle gem` command](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt)