### PR TITLE
Add `frozen_string_literal: false` to files that modify strings and run tests with frozen strings

### DIFF
--- a/.github/workflows/integration-compute-core.yml
+++ b/.github/workflows/integration-compute-core.yml
@@ -34,6 +34,8 @@ concurrency:
 jobs:
   test-compute:
     runs-on: fog-arc-runner
+    env:
+      RUBYOPT: "--enable-frozen-string-literal"
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-compute-instance_groups.yml
+++ b/.github/workflows/integration-compute-instance_groups.yml
@@ -35,6 +35,8 @@ concurrency:
 jobs:
   test:
     runs-on: fog-arc-runner
+    env:
+      RUBYOPT: "--enable-frozen-string-literal"
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-compute-loadbalancing.yml
+++ b/.github/workflows/integration-compute-loadbalancing.yml
@@ -35,6 +35,8 @@ concurrency:
 jobs:
   test:
     runs-on: fog-arc-runner
+    env:
+      RUBYOPT: "--enable-frozen-string-literal"
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-compute-networking.yml
+++ b/.github/workflows/integration-compute-networking.yml
@@ -34,6 +34,8 @@ concurrency:
 jobs:
   test:
     runs-on: fog-arc-runner
+    env:
+      RUBYOPT: "--enable-frozen-string-literal"
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-monitoring.yml
+++ b/.github/workflows/integration-monitoring.yml
@@ -35,6 +35,8 @@ concurrency:
 jobs:
   test:
     runs-on: fog-arc-runner
+    env:
+      RUBYOPT: "--enable-frozen-string-literal"
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-pubsub.yml
+++ b/.github/workflows/integration-pubsub.yml
@@ -35,6 +35,8 @@ concurrency:
 jobs:
   test:
     runs-on: fog-arc-runner
+    env:
+      RUBYOPT: "--enable-frozen-string-literal"
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-sql.yml
+++ b/.github/workflows/integration-sql.yml
@@ -35,6 +35,8 @@ concurrency:
 jobs:
   test:
     runs-on: fog-arc-runner
+    env:
+      RUBYOPT: "--enable-frozen-string-literal"
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/integration-storage.yml
+++ b/.github/workflows/integration-storage.yml
@@ -36,6 +36,8 @@ concurrency:
 jobs:
   test:
     runs-on: fog-arc-runner
+    env:
+      RUBYOPT: "--enable-frozen-string-literal"
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2' ]

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -14,6 +14,8 @@ concurrency:
 jobs:
   test-unit:
     runs-on: ubuntu-latest
+    env:
+      RUBYOPT: "--enable-frozen-string-literal"
     strategy:
       matrix:
         ruby-version: [ '3.0', '3.1', '3.2', 'head', 'truffleruby-head']

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,6 @@ Style/FormatString:
 Style/RegexpLiteral:
   Enabled: false
 
-#TODO: this needs to be adressed not through the linter
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,9 @@ Style/FormatString:
 Style/RegexpLiteral:
   Enabled: false
 
+# TODO: Some files modify strings in place, so we need to disable this cop.
+# ci runs with RUBYOPT="--enable-frozen-string-literal", files that modify
+# strings have frozen_string_literal: false.
 Style/FrozenStringLiteralComment:
   Enabled: false
 

--- a/lib/fog/google/storage/storage_json/real.rb
+++ b/lib/fog/google/storage/storage_json/real.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 module Fog
   module Google
     class StorageJSON

--- a/lib/fog/google/storage/storage_json/utils.rb
+++ b/lib/fog/google/storage/storage_json/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require "addressable"
 
 module Fog

--- a/lib/fog/google/storage/storage_xml/real.rb
+++ b/lib/fog/google/storage/storage_xml/real.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 module Fog
   module Google
     class StorageXML

--- a/lib/fog/google/storage/storage_xml/utils.rb
+++ b/lib/fog/google/storage/storage_xml/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 module Fog
   module Google
     class StorageXML


### PR DESCRIPTION
Partially addresses #639. It runs tests with frozen strings, but allows modifying strings for those files with `frozen_string_literal: false`. This should allow people using for to run with `RUBYOPT="--enable-frozen-string-literal"`. Next step would involve not modifying strings, but this was more involved, so I thought it would make sense to do this first.
