### PR TITLE
feat(server): update disk attachment method to use new attached_disk_obj method

### DIFF
--- a/lib/fog/google/compute/models/server.rb
+++ b/lib/fog/google/compute/models/server.rb
@@ -277,7 +277,7 @@ module Fog
           requires :identity, :zone
 
           if disk.is_a? Disk
-            disk_obj = disk.get_attached_disk
+            disk_obj = disk.attached_disk_obj(**attached_disk_options)
           elsif disk.is_a? String
             disk_obj = service.disks.attached_disk_obj(disk, **attached_disk_options)
           end


### PR DESCRIPTION
looks like this was lost in translation on https://github.com/fog/fog-google/commit/f14b3b996fa8b5806b142e3260434307e3e8566f

closes #610
