### PR TITLE
Raise exception if errors occur during server creation

### DIFF
--- a/lib/fog/google/compute/models/operation.rb
+++ b/lib/fog/google/compute/models/operation.rb
@@ -27,17 +27,6 @@ module Fog
         attribute :zone
 
 
-        # {:errors=>
-        #   [{:code=>"QUOTA_EXCEEDED",
-        #     :error_details=>
-        #      [{:quota_info=>
-        #         {:dimensions=>{:region=>"us-east4"},
-        #          :limit=>500,
-        #          :limit_name=>"SSD-TOTAL-GB-per-project-region",
-        #          :metric_name=>"compute.googleapis.com/ssd_total_storage"}}],
-        #     :message=>"Quota 'SSD_TOTAL_GB' exceeded.  Limit: 500.0 in region us-east4."}
-        #   ]
-        # }
         class ErrorInfo
           attr_accessor :code
           attr_accessor :error_details
@@ -56,6 +45,20 @@ module Fog
           end
         end  # ErrorInfo
 
+        # {:errors => [
+        #    {:code => "QUOTA_EXCEEDED",
+        #     :error_details => [
+        #       {:quota_info=>
+        #         {:dimensions=>{:region=>"us-east4"},
+        #          :limit=>500,
+        #          :limit_name=>"SSD-TOTAL-GB-per-project-region",
+        #          :metric_name=>"compute.googleapis.com/ssd_total_storage"
+        #         }
+        #       }
+        #     ],
+        #     :message=>"Quota 'SSD_TOTAL_GB' exceeded.  Limit: 500.0 in region us-east4."
+        #   }
+        # ]}
         class QuotaInfo < ErrorInfo
           def initialize(attributes = {})
             code = attributes[:code]
@@ -93,6 +96,32 @@ module Fog
           end
         end  # QuotaInfo
 
+        # {:errors => [
+        #    {:code => "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+        #     :error_details => [
+        #       {:help => {:links=>[{:description=>"Troubleshooting documentation", :url=>"https://cloud.google.com/compute/docs/resource-error"}]}},
+        #       {:localized_message => {
+        #          :locale=>"en-US",
+        #          :message=> "A c3d-highmem-4 VM instance is currently unavailable in the us-east4-b zone. Try requesting the VM in another zone. For more information, view the troubleshooting documentation."
+        #       }},
+        #       {:error_info => {
+        #          :domain=>"compute.googleapis.com",
+        #          :metadatas=>{:attachment=>"", :vmType=>"c3d-highmem-4", :zone=>"us-east4-b", :zonesAvailable=>""},
+        #          :reason=>"stockout"
+        #       }}
+        #     ],
+        #     :message => "The zone 'projects/projname/zones/us-east4-b' does not have enough resources available to fulfill the request.  '(resource type:compute)'."
+        #   }
+        # ]}
+        class ResourcePoolInfo < ErrorInfo  # placeholder in case there is a need for a future message_pretty
+          def initialize(attributes = {})
+            code = attributes[:code]
+            raise Fog::Errors::Error.new("Invalid error code: #{code}") if code !~ /RESOURCE_POOL_EXHAUSTED/
+
+            super(attributes)
+          end
+        end  # ResourcePoolInfo
+
 
         def error?
           ! error.nil?
@@ -118,9 +147,16 @@ module Fog
           zone.nil? ? nil : zone.split("/")[-1]
         end
 
+        # https://docs.cloud.google.com/compute/docs/reference/rest/v1/errors
         def error_info_class(code)
           case code
             when "QUOTA_EXCEEDED" then QuotaInfo
+
+            when "REGION_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS" then ResourcePoolInfo
+            when "RESOURCE_POOL_EXHAUSTED"                     then ResourcePoolInfo
+            when "ZONE_RESOURCE_POOL_EXHAUSTED"                then ResourcePoolInfo
+            when "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS"   then ResourcePoolInfo
+
             else
               ErrorInfo
           end

--- a/lib/fog/google/compute/models/server.rb
+++ b/lib/fog/google/compute/models/server.rb
@@ -563,6 +563,17 @@ module Fog
                       .new(:service => service)
                       .get(data.name, data.zone)
           operation.wait_for { ready? }
+
+          # Handle errors
+          if operation.error?
+            msg = "Error creating server #{name}."
+
+            err = operation.primary_error
+            msg = "#{msg} #{err.message_pretty}" unless err.nil?
+
+            raise Fog::Errors::Error.new(msg)
+          end
+
           reload
         end
 

--- a/test/unit/compute/test_operation.rb
+++ b/test/unit/compute/test_operation.rb
@@ -152,4 +152,29 @@ class UnitTestOperation < Minitest::Test
     err = op.primary_error
     assert_equal "Quota 'SSD_TOTAL_GB' exceeded.  Limit: 500.0 compute.googleapis.com/ssd_total_storage.  Limit: 999.0 in region us-west1.", err.message_pretty
   end
+
+  def test_message_pretty_zone_pool_exhausted_with_details
+    error= {:errors => [
+             {:code => "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS",
+              :error_details => [
+                {:help => {:links=>[{:description=>"Troubleshooting documentation", :url=>"https://cloud.google.com/compute/docs/resource-error"}]}},
+                {:localized_message => {
+                   :locale=>"en-US",
+                   :message=> "A c3d-highmem-4 VM instance is currently unavailable in the us-east4-b zone. Try requesting the VM in another zone. For more information, view the troubleshooting documentation."
+                }},
+                {:error_info => {
+                   :domain=>"compute.googleapis.com",
+                   :metadatas=>{:attachment=>"", :vmType=>"c3d-highmem-4", :zone=>"us-east4-b", :zonesAvailable=>""},
+                   :reason=>"stockout"
+                }}
+              ],
+              :message => "The zone 'projects/projname/zones/us-east4-b' does not have enough resources available to fulfill the request.  '(resource type:compute)'."
+            }
+          ]}
+
+    op = Fog::Google::Compute::Operation.new(:error => error, :name => OP_NAME)
+    err = op.primary_error
+    assert_equal "The zone 'projects/projname/zones/us-east4-b' does not have enough resources available to fulfill the request.  '(resource type:compute)'.", err.message_pretty
+  end
+
 end


### PR DESCRIPTION
The current behavior of Fog::Google::Compute::Server#save returns successfully despite no server being created when Fog::Google::Compute::Operations#new returns an error operation. This PR primarily revises that behavior and instead raises Fog::Errors::Error.

In addition, this PR implements specific message formatting when receiving these error codes:

- REGION_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS
- RESOURCE_POOL_EXHAUSTED
- ZONE_RESOURCE_POOL_EXHAUSTED
- ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS

This PR is analogous to previous https://github.com/fog/fog-google/pull/648 for Fog::Google::Compute::Disk#save.